### PR TITLE
Refactor docker-compose to use a setup job

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,28 @@
-version: "3"
+version: "3.4"
+
+x-takahe-common:
+  &takahe-common
+    build: .
+    image: takahe:latest
+    environment:
+      DJANGO_SETTINGS_MODULE: takahe.settings.production
+      PGHOST: db
+      PGDATABASE: takahe
+      PGUSER: postgres
+      PGPASSWORD: insecure_password
+      TAKAHE_SECRET_KEY: insecure_secret
+      TAKAHE_MAIN_DOMAIN: example.com
+      TAKAHE_EMAIL_CONSOLE_ONLY: True
+      TAKAHE_MEDIA_BACKEND: local
+      TAKAHE_AUTO_ADMIN_EMAIL: admin@example.com
+    networks:
+      - external_network
+      - internal_network
+    restart: on-failure
+    depends_on:
+      - db
+    volumes:
+      - ..:/takahe/
 
 services:
   db:
@@ -9,34 +33,21 @@ services:
       - dbdata:/var/lib/postgresql/data
     networks:
       - internal_network
-    restart: always
+    restart: unless-stopped
     environment:
-      - "POSTGRES_DB=takahe"
-      - "POSTGRES_USER=postgres"
-      - "POSTGRES_PASSWORD=insecure_password"
+      POSTGRES_DB: takahe
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: insecure_password
 
   web:
-    build: .
-    image: takahe:latest
-    environment:
-      - "DJANGO_SETTINGS_MODULE=takahe.settings.production"
-      - "PGHOST=db"
-      - "PGDATABASE=takahe"
-      - "PGUSER=postgres"
-      - "PGPASSWORD=insecure_password"
-      - "TAKAHE_SECRET_KEY=insecure_secret"
-      - "TAKAHE_MAIN_DOMAIN=example.com"
-      - "TAKAHE_EMAIL_CONSOLE_ONLY=True"
-      - "TAKAHE_MEDIA_BACKEND=local"
-      - "TAKAHE_AUTO_ADMIN_EMAIL=admin@example.com"
-    networks:
-      - external_network
-      - internal_network
-    restart: always
-    depends_on:
-      - db
+    <<: *takahe-common
     ports:
       - "8000:8000"
+    command: ["/takahe/manage.py", "runserver", "0.0.0.0:8000"]
+
+  setup:
+    <<: *takahe-common
+    command: ["/takahe/manage.py", "migrate"]
 
 networks:
   internal_network:


### PR DESCRIPTION
I'm not sure how much or even if you use the docker-compose code for development, but I noticed a couple things that have bit me on other projects so I made this PR to see if this is somewhere that I can help since I do a lot of Docker stuff these days.

First an explanation:

When running a Django project in a cluster-like deployment like Kubernetes, we found that the pattern of having a Docker image start with running migrations was a Bad Idea 'cause your deployment would spin up 5 `web` pods and all 5 would try to run the migrations at the same time leading to some rather scary/confusing results.  On top of that, it reduces your pod start time, which sucks for scalability (horizontal pod autoscaling etc.)

The fix that made the most sense for us was instead to use a `setup` job.  The same Docker image, but deployed with a different `command` argument that simply ran `migrate` and `collectstatic` and then exited with `0`.  That way, you could stand up 100 instances quickly, scaling up and down without any risk of running migrations for each one.

To replicate that experience in development, (which is the only place we use `docker-compose`), we have two "services": `web` and `setup`.  The former runs the webserver until it's stopped, while the latter runs the setup and then dies happy.

If you agree that this is a good design, then 2 more things need to be changed:

1. The `Dockerfile` should have its `CMD` line removed as that's defined in the deployment anyway.  In `docker-compose` we use the `runserver` and for production, we'd use `gunicorn takahe.wsgi:application -b 0.0.0.0:8000`.
2. The `start.sh` script can be deleted entirely.

Finally, adding an `ENTRYPOINT` to the `Dockerfile` that confirms the availability of the database before starting the webserver is probably a good idea.  Without it, the server can start without an active connection and just rejects HTTP requests 'til you restart the service manually (ew).  In the current setup, this doesn't happen because as the webserver starts up, it runs `migrate` which fails until the webserver is up.  Something like this is probably sufficient:

```bash
#!/bin/bash

echo "Checking for a working connection to the database
nc -z ${PGHOST} 5432
```

...but you could do something more *Djangoesqe* if you like: `/takahe/manage.py check_ready`

Anyway, this is all meant as a "use this if you feel like it" PR.  Doing my own development, I can always just use a `docker-compose.override.yaml` file and work any way I like, but since I was hoping to deploy Takahē to my local k3s cluster, I started hacking on it from that point of view.

Regardless of whether you use this PR or not, I hope you'll consider some other options for working around running `migrate` at the start of every webservice.