### PR TITLE
fix: use repository root as build context in `docker-compose.yml`

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,10 @@ version: "3.4"
 
 x-takahe-common:
   &takahe-common
-    build: .
+    build:
+      context: ..
+      dockerfile: ./docker/Dockerfile
+
     image: takahe:latest
     environment:
       DJANGO_SETTINGS_MODULE: takahe.settings.development


### PR DESCRIPTION
Hello, I like this project! It has a nice clean and beautiful look and uses the latest Python async capability for scalability. 🙂 

When I tried `make compose_up`, I encountered the same error as (#17 and #32) where `requirements.txt` is missing. The error can be avoided if I run `make image` before running `make compose_up` but it seems that it doesn't solve the issue that `docker-compose build` fails after modifying some codes and rebuilding the container.

This PR fixes the issue where `docker-compose` fails to build `takahe:latest` container. The cause of the issue was the build context for docker-compose is different from the one of `docker build`. Currently, `make image` uses the repository root as a build context while `make compose_up` will use `docker/` directory as a build context. That's why docker-compose couldn't find the required files during building.

Documentation on docker website ([Compose file build reference | Docker Documentation](https://docs.docker.com/compose/compose-file/build/)) was helpful in understanding how to specify the correct context and `Dockerfile` path.