### PR TITLE
Local-only posting

### DIFF
--- a/activities/migrations/0001_initial.py
+++ b/activities/migrations/0001_initial.py
@@ -60,6 +60,7 @@ class Migration(migrations.Migration):
                     models.IntegerField(
                         choices=[
                             (0, "Public"),
+                            (4, "Local Only"),
                             (1, "Unlisted"),
                             (2, "Followers"),
                             (3, "Mentioned"),

--- a/activities/views/posts.py
+++ b/activities/views/posts.py
@@ -208,9 +208,8 @@ class Compose(FormView):
         ] = self.request.identity.config_identity.default_post_visibility
         if self.reply_to:
             initial["reply_to"] = self.reply_to.pk
+            initial["visibility"] = self.reply_to.visibility
             initial["text"] = f"@{self.reply_to.author.handle} "
-            if self.reply_to.visibility == Post.Visibilities.local_only:
-                initial["visibility"] = Post.Visibilities.local_only
         return initial
 
     def form_valid(self, form):

--- a/activities/views/posts.py
+++ b/activities/views/posts.py
@@ -172,6 +172,7 @@ class Compose(FormView):
         visibility = forms.ChoiceField(
             choices=[
                 (Post.Visibilities.public, "Public"),
+                (Post.Visibilities.local_only, "Local Only"),
                 (Post.Visibilities.unlisted, "Unlisted"),
                 (Post.Visibilities.followers, "Followers & Mentioned Only"),
                 (Post.Visibilities.mentioned, "Mentioned Only"),
@@ -207,8 +208,9 @@ class Compose(FormView):
         ] = self.request.identity.config_identity.default_post_visibility
         if self.reply_to:
             initial["reply_to"] = self.reply_to.pk
-            initial["visibility"] = Post.Visibilities.unlisted
             initial["text"] = f"@{self.reply_to.author.handle} "
+            if self.reply_to.visibility == Post.Visibilities.local_only:
+                initial["visibility"] = Post.Visibilities.local_only
         return initial
 
     def form_valid(self, form):

--- a/templates/activities/_post.html
+++ b/templates/activities/_post.html
@@ -15,6 +15,8 @@
             <i class="visibility fa-solid fa-lock" title="Followers Only"></i>
         {% elif post.visibility == 3 %}
             <i class="visibility fa-solid fa-at" title="Mentioned Only"></i>
+        {% elif post.visibility == 4 %}
+        <i class="visibility fa-solid fa-link-slash" title="Local Only"></i>
         {% endif %}
         <a href="{{ post.url }}">
             {% if post.published %}

--- a/tests/activities/models/test_post_targets.py
+++ b/tests/activities/models/test_post_targets.py
@@ -1,0 +1,107 @@
+import pytest
+from asgiref.sync import async_to_sync
+
+from activities.models import Post
+from users.models import Follow
+
+
+@pytest.mark.django_db
+def test_post_targets_simple(identity, other_identity, remote_identity):
+    """
+    Tests that a simple top level post returns the correct targets.
+    """
+    # Test a post with no mentions targets author
+    post = Post.objects.create(
+        content="<p>Hello</p>",
+        author=identity,
+        local=True,
+    )
+    targets = async_to_sync(post.aget_targets)()
+    assert targets == {identity}
+
+    # Test remote reply targets original post author
+    Post.objects.create(
+        content="<p>Reply</p>",
+        author=remote_identity,
+        local=False,
+        in_reply_to=post.absolute_object_uri(),
+    )
+    targets = async_to_sync(post.aget_targets)()
+    assert targets == {identity}
+
+    # Test a post with local and remote mentions
+    post = Post.objects.create(
+        content="<p>Hello @test and @other</p>",
+        author=identity,
+        local=True,
+    )
+    # Mentions are targeted
+    post.mentions.add(remote_identity)
+    post.mentions.add(other_identity)
+    targets = async_to_sync(post.aget_targets)()
+    # Targets everyone
+    assert targets == {identity, other_identity, remote_identity}
+
+    # Test remote post with mentions
+    post.local = False
+    post.save()
+    targets = async_to_sync(post.aget_targets)()
+    # Only targets locals
+    assert targets == {identity, other_identity}
+
+
+@pytest.mark.django_db
+def test_post_local_only(identity, other_identity, remote_identity):
+    """
+    Tests that a simple top level post returns the correct targets.
+    """
+    # Test a short username (remote)
+    post = Post.objects.create(
+        content="<p>Hello @test and @other</p>",
+        author=identity,
+        local=True,
+        visibility=Post.Visibilities.local_only,
+    )
+    post.mentions.add(remote_identity)
+    post.mentions.add(other_identity)
+
+    # Remote mention is not targeted
+    post.mentions.add(remote_identity)
+    targets = async_to_sync(post.aget_targets)()
+    assert targets == {identity, other_identity}
+
+
+@pytest.mark.django_db
+def test_post_followers(identity, other_identity, remote_identity):
+
+    Follow.objects.create(source=other_identity, target=identity)
+    Follow.objects.create(source=remote_identity, target=identity)
+
+    # Test Public post w/o mentions targets self and followers
+    post = Post.objects.create(
+        content="<p>Hello</p>",
+        author=identity,
+        local=True,
+        visibility=Post.Visibilities.public,
+    )
+    targets = async_to_sync(post.aget_targets)()
+    assert targets == {identity, other_identity, remote_identity}
+
+    # Remote post only targets local followers
+    post.local = False
+    post.save()
+    targets = async_to_sync(post.aget_targets)()
+    assert targets == {identity, other_identity}
+
+    # Local Only post only targets local followers
+    post.local = True
+    post.visibility = Post.Visibilities.local_only
+    post.save()
+    targets = async_to_sync(post.aget_targets)()
+    assert targets == {identity, other_identity}
+
+    # Mentioned posts do not target unmentioned followers
+    post.visibility = Post.Visibilities.mentioned
+    post.save()
+    targets = async_to_sync(post.aget_targets)()
+    assert targets == {identity}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,11 +68,16 @@ def user() -> User:
 
 @pytest.fixture
 @pytest.mark.django_db
-def identity(user):
+def domain() -> Domain:
+    return Domain.objects.create(domain="example.com", local=True, public=True)
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def identity(user, domain) -> Identity:
     """
     Creates a basic test identity with a user and domain.
     """
-    domain = Domain.objects.create(domain="example.com", local=True, public=True)
     identity = Identity.objects.create(
         actor_uri="https://example.com/@test@example.com/",
         username="test",
@@ -85,8 +90,24 @@ def identity(user):
 
 
 @pytest.fixture
+def other_identity(user, domain) -> Identity:
+    """
+    Creates a different basic test identity with a user and domain.
+    """
+    identity = Identity.objects.create(
+        actor_uri="https://example.com/@other@example.com/",
+        username="other",
+        domain=domain,
+        name="Other User",
+        local=True,
+    )
+    identity.users.set([user])
+    return identity
+
+
+@pytest.fixture
 @pytest.mark.django_db
-def remote_identity():
+def remote_identity() -> Identity:
     """
     Creates a basic remote test identity with a domain.
     """


### PR DESCRIPTION
Initial effort for adding Local-Only support (#27)

@andrewgodwin wanted to get your generic feedback on this before trudging along too far. Does controlling the local vs federated entirely in fan_out and `to_ap()` work with your vision? ~~I don't like that the no-op fanouts generate a lot of chatter for non-local identities, but I haven't seen a better way yet.~~ (`Post.aget_targets()` filters out the potential no-op chatter)

**Notes:**
* There were unrelated updates in the migrations