### PR TITLE
Set content type when serving object, closes #37

### DIFF
--- a/activities/views/posts.py
+++ b/activities/views/posts.py
@@ -75,11 +75,8 @@ class Individual(TemplateView):
         if not self.post_obj.local:
             return redirect(self.post_obj.object_uri)
         return JsonResponse(
-            canonicalise(
-                self.post_obj.to_ap(),
-                include_security=True
-            ),
-            content_type='application/activity+json'
+            canonicalise(self.post_obj.to_ap(), include_security=True),
+            content_type="application/activity+json",
         )
 
 

--- a/activities/views/posts.py
+++ b/activities/views/posts.py
@@ -74,7 +74,13 @@ class Individual(TemplateView):
         # If this not a local post, redirect to its canonical URI
         if not self.post_obj.local:
             return redirect(self.post_obj.object_uri)
-        return JsonResponse(canonicalise(self.post_obj.to_ap(), include_security=True))
+        return JsonResponse(
+            canonicalise(
+                self.post_obj.to_ap(),
+                include_security=True
+            ),
+            content_type='application/activity+json'
+        )
 
 
 @method_decorator(identity_required, name="dispatch")

--- a/users/views/identity.py
+++ b/users/views/identity.py
@@ -56,11 +56,8 @@ class ViewIdentity(ListView):
         if not identity.local:
             return redirect(identity.actor_uri)
         return JsonResponse(
-            canonicalise(
-                identity.to_ap(),
-                include_security=True
-            ),
-            content_type='application/activity+json'
+            canonicalise(identity.to_ap(), include_security=True),
+            content_type="application/activity+json",
         )
 
     def get_queryset(self):

--- a/users/views/identity.py
+++ b/users/views/identity.py
@@ -55,7 +55,13 @@ class ViewIdentity(ListView):
         # If this not a local actor, redirect to their canonical URI
         if not identity.local:
             return redirect(identity.actor_uri)
-        return JsonResponse(canonicalise(identity.to_ap(), include_security=True))
+        return JsonResponse(
+            canonicalise(
+                identity.to_ap(),
+                include_security=True
+            ),
+            content_type='application/activity+json'
+        )
 
     def get_queryset(self):
         return (


### PR DESCRIPTION
Required to enable post and actor discovery, _specifically_ for Mastodon (other's aren't so picky)