### PR TITLE
Relax S3 URI parsing

### DIFF
--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -15,7 +15,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 class MediaBackendUrl(AnyUrl):
     host_required = False
-    allowed_schemes = {'s3', 'gcs', 'local'}
+    allowed_schemes = {"s3", "gcs", "local"}
 
 
 def as_bool(v: Optional[Union[str, List[str]]]):


### PR DESCRIPTION
Create a new URL validator for `MEDIA_BACKEND` to allow for S3 specific quirks (mainly, no host). Also modify the S3 parsing code to allow for lack of username/password/host.