### PR TITLE
Fix case typo in email settings

### DIFF
--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -278,7 +278,7 @@ if SETUP.EMAIL_SERVER:
     elif parsed.scheme == "smtp":
         EMAIL_HOST = parsed.hostname
         EMAIL_PORT = parsed.port
-        EMAIl_HOST_USER = parsed.username
+        EMAIL_HOST_USER = parsed.username
         EMAIL_HOST_PASSWORD = parsed.password
         EMAIL_USE_TLS = as_bool(query.get("tls"))
         EMAIL_USE_SSL = as_bool(query.get("ssl"))


### PR DESCRIPTION
The `L` in `EMAIL_HOST_USER` has the wrong case in the SMTP parser, which had me tearing my hair out for a while (if _either_ user or password aren't set, Django Email just skips auth completely, rather than returning any kind of sane error)