### PR TITLE
docs: fix code block syntax

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,0 +1,29 @@
+name: Test Documentation Build
+
+on:
+  push:
+    paths:
+      - 'docs/**'
+  pull_request:
+    paths:
+      - 'docs/**'
+
+jobs:
+  test_docs:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install dependencies for docs
+        run: |
+          python -m pip install -r docs/requirements.txt
+      - name: Build documentation
+        run: |
+          cd docs && make clean && make html

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,12 +1,6 @@
 name: Test Documentation Build
 
-on:
-  push:
-    paths:
-      - 'docs/**'
-  pull_request:
-    paths:
-      - 'docs/**'
+on: [push, pull_request]
 
 jobs:
   test_docs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   test:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -101,7 +101,7 @@ You will need to run Stator in order to have background actions work::
 
     ./manage.py runstator
 
-Make yourself a superuser account in order to log in:
+Make yourself a superuser account in order to log in::
 
     ./manage.py createsuperuser
 


### PR DESCRIPTION
This PR contains two changes:
- Just a trivial markup fix
- Add GitHub Actions workflow to build documentation 

### Markup fix

The markup fix is just adding a missing colon (`:`) in the Contributing page: [Contributing - Takahē documentation](https://docs.jointakahe.org/en/latest/contributing/#direct-installation)

**before**
![Screenshot 2022-11-28 at 23 20 03](https://user-images.githubusercontent.com/1425259/204309029-e0ada734-739b-4ecf-a751-d7268ea23120.png)

**after**
![Screenshot 2022-11-28 at 23 19 51](https://user-images.githubusercontent.com/1425259/204309032-84f4cab0-348d-4666-b869-b9da97b33dd2.png)

### GitHub Actions workflow for docs

I also add a new workflow only targeting docs to ensure buildable and limiting the condition of `test.yml`. With this change, commits changing files under `docs/**` will trigger only `test-docs.yml` and can avoid triggering `test.yml`, which consumes a bit longer time.
