### PR TITLE
produce slightly prettier unique names for upload file names

### DIFF
--- a/core/uploads.py
+++ b/core/uploads.py
@@ -1,6 +1,5 @@
 import base64
 import os
-import uuid
 
 from django.utils import timezone
 
@@ -11,5 +10,5 @@ def upload_namer(prefix, instance, filename):
     """
     now = timezone.now()
     _, old_extension = os.path.splitext(filename)
-    new_filename = base64.b32encode(uuid.uuid4().bytes).decode("ascii")
+    new_filename = base64.b32encode(os.urandom(15)).decode("ascii").lower()
     return f"{prefix}/{now.year}/{now.month}/{now.day}/{new_filename}{old_extension}"


### PR DESCRIPTION
```
>>> base64.b32encode(uuid.uuid4().bytes).decode("ascii")
'DKNZVTTCVRHYHH42LJO7WG4BNE======'
'UG33VWPGVBCTDCHDUZU5KZHQRY======'
'LZMJ6BM2VFBENP65V6LSPJHKZA======'

>>> base64.b32encode(os.urandom(15)).decode("ascii").lower()
'zzma44xtkemggusabzifsybx'
'iltrfmcvsokrs2ha6l4epprp'
'nz6fjcvmxigzwn5it5ztiwy2'
```