### PR TITLE
Add a special release task to Procfile to run migrations before startup.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: gunicorn takahe.wsgi:application --workers 8
 worker: python manage.py runstator
+release: python manage.py migrate


### PR DESCRIPTION
A task called release is treated differently from the rest. Both Heroku and dokku will run this _just once_ before the container starts up.

See:
- https://devcenter.heroku.com/articles/release-phase#specifying-release-phase-tasks
- https://dokku.com/docs/advanced-usage/deployment-tasks/#procfile-release-command