### PR TITLE
Add TAKAHE_DEFAULT_TIMEOUT with default of 5.0

### DIFF
--- a/core/signatures.py
+++ b/core/signatures.py
@@ -7,9 +7,11 @@ import httpx
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from django.conf import settings
 from django.http import HttpRequest
 from django.utils import timezone
 from django.utils.http import http_date, parse_http_date
+from httpx._types import TimeoutTypes
 from pyld import jsonld
 
 from core.ld import format_ld_date
@@ -173,6 +175,7 @@ class HttpSignature:
         key_id: str,
         content_type: str = "application/json",
         method: Literal["get", "post"] = "post",
+        timeout: TimeoutTypes = settings.SETUP.REMOTE_TIMEOUT,
     ):
         """
         Performs an async request to the given path, with a document, signed
@@ -219,7 +222,7 @@ class HttpSignature:
         )
         # Send the request with all those headers except the pseudo one
         del headers["(request-target)"]
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=timeout) as client:
             response = await client.request(
                 method,
                 uri,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,4 +19,5 @@ in alpha. For more information about Takahē, see
    contributing
    domains
    stator
+   tuning
    releases/index

--- a/docs/tuning.rst
+++ b/docs/tuning.rst
@@ -1,0 +1,16 @@
+Tuning
+======
+
+This page contains a collection of tips and settings that can be used to
+tune your server based upon its users and the other servers it federates
+with.
+
+Federating
+----------
+
+Environment Variable:
+
+* ``TAKAHE_REMOTE_TIMEOUT`` is the number of seconds Takahē will allow when
+  making remote requests to other Fediverse instances. This may also be a
+  tuple of four floats to set the timeouts for connect, read, write, and
+  pool. Example ``TAKAHE_REMOTE_TIMEOUT='[0.5, 1.0, 1.0, 0.5]'``

--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -90,6 +90,10 @@ class Settings(BaseSettings):
     MEDIA_ROOT: str = str(BASE_DIR / "media")
     MEDIA_BACKEND: Optional[MediaBackendUrl] = None
 
+    #: Request timeouts to use when talking to other servers Either
+    #: float or tuple of floats for (connect, read, write, pool)
+    REMOTE_TIMEOUT: float | tuple[float, float, float, float] = 5.0
+
     #: If search features like full text search should be enabled.
     #: (placeholder setting, no effect)
     SEARCH: bool = True


### PR DESCRIPTION
* Timeout of 5.0 was arbitrary (and generous) to avoid blocking until gunicorn cuts the connection
* Start of a tuning docs page.