### PR TITLE
Optimized deb packages installed in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,12 +3,24 @@ ARG IMAGE_LABEL=3.11.0-slim-buster
 
 FROM ${IMAGE_HOST}:${IMAGE_LABEL}
 
-RUN apt-get update && apt-get -y install libpq-dev libxml2-dev libxslt1-dev zlib1g-dev python3-dev build-essential
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libpq5 \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements.txt
 
-RUN pip3 install --upgrade pip \
-    && pip3 install --upgrade -r requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        gcc \
+        libc6-dev \
+        libpq-dev \
+    && python3 -m pip install --upgrade -r requirements.txt \
+    && apt-get purge -y --auto-remove \
+        gcc \
+        libc6-dev \
+        libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY . /takahe
 


### PR DESCRIPTION
I optimized the Deb packages installed in Docker, making the installation of the development libraries temporary for the installation of the Python requirements and leaving the one package needed to run psycopg permanent.

I have also removed the installation of unnecessary packages. Updating pip is an extra layer that should be addressed by updating the official Python image used as a base.

The final image is thus reduced by 50% for the same features.

#### Before
```bash
(takahe) paulox@net:~/Projects/takahe$ docker image ls
REPOSITORY        TAG                  IMAGE ID       CREATED              SIZE
takahe            latest               c9901e63c721   About a minute ago   980MB
postgres          15-alpine            9104349146d9   3 days ago           243MB
python            3.11.0-slim-buster   20d9cc821c50   2 weeks ago          121MB
```

#### After
```bash
(takahe) paulox@net:~/Projects/takahe$ docker image ls
REPOSITORY        TAG                  IMAGE ID       CREATED          SIZE
takahe            latest               28f8faab0ad9   12 seconds ago   528MB
postgres          15-alpine            9104349146d9   3 days ago       243MB
python            3.11.0-slim-buster   20d9cc821c50   2 weeks ago      121MB
```