### PR TITLE
Make max media upload size configurable

### DIFF
--- a/activities/views/compose.py
+++ b/activities/views/compose.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.decorators import method_decorator
@@ -158,10 +159,12 @@ class ImageUpload(FormView):
 
         def clean_image(self):
             value = self.cleaned_data["image"]
-            if value.size > 1024 * 1024 * 10:
+            max_mb = settings.SETUP.POST_MEDIA_UPLOAD_MAX_MB
+            max_bytes = max_mb * 1024 * 1024
+            if value.size > max_bytes:
                 # Erase the file from our data to stop trying to show it again
                 self.files = {}
-                raise forms.ValidationError("File must be 10MB or less")
+                raise forms.ValidationError(f"File must be {max_mb}MB or less")
             return value
 
     def form_invalid(self, form):

--- a/activities/views/compose.py
+++ b/activities/views/compose.py
@@ -159,7 +159,7 @@ class ImageUpload(FormView):
 
         def clean_image(self):
             value = self.cleaned_data["image"]
-            max_mb = settings.SETUP.POST_MEDIA_UPLOAD_MAX_MB
+            max_mb = settings.SETUP.MEDIA_MAX_IMAGE_FILESIZE_MB
             max_bytes = max_mb * 1024 * 1024
             if value.size > max_bytes:
                 # Erase the file from our data to stop trying to show it again

--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -90,6 +90,8 @@ class Settings(BaseSettings):
     MEDIA_ROOT: str = str(BASE_DIR / "media")
     MEDIA_BACKEND: Optional[MediaBackendUrl] = None
 
+    POST_MEDIA_UPLOAD_MAX_MB: int = 10
+
     #: Request timeouts to use when talking to other servers Either
     #: float or tuple of floats for (connect, read, write, pool)
     REMOTE_TIMEOUT: float | tuple[float, float, float, float] = 5.0

--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -90,7 +90,10 @@ class Settings(BaseSettings):
     MEDIA_ROOT: str = str(BASE_DIR / "media")
     MEDIA_BACKEND: Optional[MediaBackendUrl] = None
 
-    POST_MEDIA_UPLOAD_MAX_MB: int = 10
+    #: Maximum filesize when uploading images. Increasing this may increase memory utilization
+    #: because all images with a dimension greater than 2000px are resized to meet that limit, which
+    #: is necessary for compatibility with Mastodon’s image proxy.
+    MEDIA_MAX_IMAGE_FILESIZE_MB: int = 10
 
     #: Request timeouts to use when talking to other servers Either
     #: float or tuple of floats for (connect, read, write, pool)


### PR DESCRIPTION
As some of us want to upload full-size photos and videos.

I’m pretty rusty with Django so sorry if this isn’t the idiomatic way to access the setting from a view. Please let me know if not, and I’ll fix this.

I hope to propose a follow-up change that’ll make the max image dimensions configurable. After that, someone should be able to configure their installation such that they’d be able to post, say, a 14 megabyte file of a 25 megapixel photo, and have it be uploaded, saved, and attached to a post, at the original fidelity. If so desired.