### PR TITLE
[WIP] Sentry improvements

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,3 +1,6 @@
+from django.core.exceptions import MiddlewareNotUsed
+
+from core import sentry
 from core.models import Config
 
 
@@ -11,5 +14,21 @@ class ConfigLoadingMiddleware:
 
     def __call__(self, request):
         Config.system = Config.load_system()
+        response = self.get_response(request)
+        return response
+
+
+class SentryTaggingMiddleware:
+    """
+    Sets Sentry tags at the start of the request if Sentry is configured.
+    """
+
+    def __init__(self, get_response):
+        if not sentry.SENTRY_ENABLED:
+            raise MiddlewareNotUsed()
+        self.get_response = get_response
+
+    def __call__(self, request):
+        sentry.set_takahe_app("web")
         response = self.get_response(request)
         return response

--- a/core/sentry.py
+++ b/core/sentry.py
@@ -26,11 +26,13 @@ if SENTRY_ENABLED:
     push_scope = sentry_sdk.push_scope
     set_context = sentry_sdk.set_context
     set_tag = sentry_sdk.set_tag
+    start_transaction = sentry_sdk.start_transaction
 else:
     configure_scope = noop_context
     push_scope = noop_context
     set_context = noop
     set_tag = noop
+    start_transaction = noop_context
 
 
 def set_takahe_app(name: str):

--- a/core/sentry.py
+++ b/core/sentry.py
@@ -1,0 +1,47 @@
+from contextlib import contextmanager
+
+from django.conf import settings
+
+SENTRY_ENABLED = False
+try:
+    if settings.SETUP.SENTRY_DSN:
+        import sentry_sdk
+
+        SENTRY_ENABLED = True
+except ImportError:
+    pass
+
+
+def noop(*args, **kwargs):
+    pass
+
+
+@contextmanager
+def noop_context(*args, **kwargs):
+    yield
+
+
+if SENTRY_ENABLED:
+    configure_scope = sentry_sdk.configure_scope
+    push_scope = sentry_sdk.push_scope
+    set_context = sentry_sdk.set_context
+    set_tag = sentry_sdk.set_tag
+else:
+    configure_scope = noop_context
+    push_scope = noop_context
+    set_context = noop
+    set_tag = noop
+
+
+def set_takahe_app(name: str):
+    set_tag("takahe.app", name)
+
+
+def scope_clear(scope):
+    if scope:
+        scope.clear()
+
+
+def set_transaction_name(scope, name: str):
+    if scope:
+        scope.set_transaction_name(name)

--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -10,6 +10,8 @@ import sentry_sdk
 from pydantic import AnyUrl, BaseSettings, EmailStr, Field, validator
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from takahe import __version__
+
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 
@@ -77,6 +79,8 @@ class Settings(BaseSettings):
 
     #: An optional Sentry DSN for error reporting.
     SENTRY_DSN: Optional[str] = None
+    SENTRY_SAMPLE_RATE: float = 1.0
+    TRACES_SENTRY_SAMPLE_RATE: float = 1.0
 
     #: Fallback domain for links.
     MAIN_DOMAIN: str = "example.com"
@@ -150,6 +154,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "core.middleware.SentryTaggingMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -269,10 +274,12 @@ if SETUP.SENTRY_DSN:
         integrations=[
             DjangoIntegration(),
         ],
-        traces_sample_rate=1.0,
+        traces_sample_rate=SETUP.TRACES_SENTRY_SAMPLE_RATE,
+        sample_rate=SETUP.SENTRY_SAMPLE_RATE,
         send_default_pii=True,
         environment=SETUP.ENVIRONMENT,
     )
+    sentry_sdk.set_tag("takahe.version", __version__)
 
 SERVER_EMAIL = SETUP.EMAIL_FROM
 if SETUP.EMAIL_SERVER:

--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -80,7 +80,7 @@ class Settings(BaseSettings):
     #: An optional Sentry DSN for error reporting.
     SENTRY_DSN: Optional[str] = None
     SENTRY_SAMPLE_RATE: float = 1.0
-    TRACES_SENTRY_SAMPLE_RATE: float = 1.0
+    SENTRY_TRACES_SAMPLE_RATE: float = 1.0
 
     #: Fallback domain for links.
     MAIN_DOMAIN: str = "example.com"
@@ -274,7 +274,7 @@ if SETUP.SENTRY_DSN:
         integrations=[
             DjangoIntegration(),
         ],
-        traces_sample_rate=SETUP.TRACES_SENTRY_SAMPLE_RATE,
+        traces_sample_rate=SETUP.SENTRY_TRACES_SAMPLE_RATE,
         sample_rate=SETUP.SENTRY_SAMPLE_RATE,
         send_default_pii=True,
         environment=SETUP.ENVIRONMENT,


### PR DESCRIPTION
Stator clears scope during the main loop to behave more like transactions. Transaction names are set.

Sentry tags:
* 'takahe.version'
* 'takahe.app' values 'web' or 'stator'

Added settings:
* TAKAHE_SENTRY_SAMPLE_RATE
* TAKAHE_SENTRY_TRACES_SAMPLE_RATE

For testing/evaluation, docker image `manfre/takahe-dev:latest` (only built for amd64)