### PR TITLE
fix: add missing dependencies for the arm64 build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ FROM ${IMAGE_HOST}:${IMAGE_LABEL}
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libpq5 \
+        libxslt1.1 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements.txt
@@ -15,11 +16,16 @@ RUN apt-get update \
         gcc \
         libc6-dev \
         libpq-dev \
+        # Required to build lxml on arm64.
+        libxslt1-dev \
+        zlib1g-dev \
     && python3 -m pip install --upgrade -r requirements.txt \
     && apt-get purge -y --auto-remove \
         gcc \
         libc6-dev \
         libpq-dev \
+        libxslt1-dev \
+        zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . /takahe


### PR DESCRIPTION
This PR re-adds dependencies introduced by #16. #106 optimized the container build reasonably, but it removed some dependencies required by the arm64 container.

The original #16 added three packages (`libxml2-dev`, `libxslt1-dev`, and `zlib1g-dev`) but I omitted `libxml2-dev` as it's required by `libxslt1-dev`.

I also added `libxslt1.1` which is installed by `libxslt1-dev` but required by `lxml` on runtime.

I tested a container build on M1 MacBook Air + Colima environment.
