### PR TITLE
Ignore actor delete messages for unknown actors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,7 @@ def identity(user, domain) -> Identity:
     """
     identity = Identity.objects.create(
         actor_uri="https://example.com/@test@example.com/",
+        inbox_uri="https://example.com/@test@example.com/inbox/",
         username="test",
         domain=domain,
         name="Test User",
@@ -102,6 +103,7 @@ def other_identity(user, domain) -> Identity:
     """
     identity = Identity.objects.create(
         actor_uri="https://example.com/@other@example.com/",
+        inbox_uri="https://example.com/@other@example.com/inbox/",
         username="other",
         domain=domain,
         name="Other User",
@@ -120,6 +122,7 @@ def remote_identity() -> Identity:
     domain = Domain.objects.create(domain="remote.test", local=False)
     return Identity.objects.create(
         actor_uri="https://remote.test/test-actor/",
+        inbox_uri="https://remote.test/@test/inbox/",
         profile_uri="https://remote.test/@test/",
         username="test",
         domain=domain,

--- a/tests/users/views/test_activitypub.py
+++ b/tests/users/views/test_activitypub.py
@@ -31,3 +31,25 @@ def test_webfinger_system_actor(client):
     data = client.get("/actor/", HTTP_ACCEPT="application/ld+json").json()
     assert data["id"] == "https://example.com/actor/"
     assert data["inbox"] == "https://example.com/actor/inbox/"
+
+
+@pytest.mark.django_db
+def test_delete_actor(client, identity):
+    data = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "actor": "https://mastodon.social/users/fakec8b6984105c8f15070a2",
+        "id": "https://mastodon.social/users/fakec8b6984105c8f15070a2#delete",
+        "object": "https://mastodon.social/users/fakec8b6984105c8f15070a2",
+        "signature": {
+            "created": "2022-12-06T03:54:28Z",
+            "creator": "https://mastodon.social/users/fakec8b6984105c8f15070a2#main-key",
+            "signatureValue": "This value doesn't matter",
+            "type": "RsaSignature2017",
+        },
+        "to": ["https://www.w3.org/ns/activitystreams#Public"],
+        "type": "Delete",
+    }
+    resp = client.post(
+        identity.inbox_uri, data=data, content_type="application/activity+json"
+    )
+    assert resp.status_code == 202


### PR DESCRIPTION
Fixes #97 

If we don't have a DB record for the actor, lie/no-op a quick response.