### PR TITLE
Improve the job names of GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: test py${{ matrix.python-version }}
+    name: test py${{ matrix.python-version }} with ${{ matrix.db_name }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -19,10 +19,12 @@ jobs:
           - "postgres://postgres:postgres@localhost/postgres"
           - "sqlite:///takahe.db"
         include:
-          - db: "sqlite:///takahe.db"
-            search: false
           - db: "postgres://postgres:postgres@localhost/postgres"
+            db_name: postgres
             search: true
+          - db: "sqlite:///takahe.db"
+            db_name: sqlite
+            search: false
     services:
       postgres:
         image: postgres:15


### PR DESCRIPTION
When I first see the Actions page, I'm a bit confused as there are the same two py3.10/py3.11 jobs. 

This tweaks the name of each `test` job by adding `with postgresql` or `with sqlite` string at the end.

**before**
![Screenshot 2022-12-06 at 17 32 19](https://user-images.githubusercontent.com/1425259/205922586-29b09a42-a43a-4aa5-b4a3-e4c6ac98e1a3.png)

**after**
![Screenshot 2022-12-06 at 17 31 58](https://user-images.githubusercontent.com/1425259/205922589-30ff21bc-02ec-4baf-ae5b-ecf155ebee93.png)

You can see the test run here: https://github.com/shuuji3/takahe/actions/runs/3627857982