### PR TITLE
Don't cache pip packages when building docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
         # Required to build lxml on arm64.
         libxslt1-dev \
         zlib1g-dev \
-    && python3 -m pip install --upgrade -r requirements.txt \
+    && python3 -m pip install --no-cache-dir --upgrade -r requirements.txt \
     && apt-get purge -y --auto-remove \
         gcc \
         libc6-dev \


### PR DESCRIPTION
Disabling the pip cache significantly slims down the docker image (by about 70mb in my local testing). I think the pip cache is likely not even used, since the layer that does the install will either be cached or re-built entirely.