### PR TITLE
'View in admin' link for post popup menu

### DIFF
--- a/activities/models/post.py
+++ b/activities/models/post.py
@@ -219,6 +219,7 @@ class Post(StatorModel):
         action_delete = "{view}delete/"
         action_edit = "{view}edit/"
         action_reply = "/compose/?reply_to={self.id}"
+        admin_edit = "/djadmin/activities/post/{self.id}/change/"
 
         def get_scheme(self, url):
             return "https"

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -954,12 +954,13 @@ table.metadata td.name {
 
 .post .actions menu.enabled {
     display: block;
+    z-index: 10;
 }
 
 .post .actions menu a {
     text-align: left;
     display: block;
-    width: 160px;
+    width: 165px;
     font-size: 15px;
 }
 

--- a/templates/activities/_post.html
+++ b/templates/activities/_post.html
@@ -49,6 +49,11 @@
                 <i class="fa-solid fa-arrow-up-right-from-square"></i> See Original
               </a>
             {% endif %}
+            {% if request.user.admin %}
+            <a href="{{ post.urls.admin_edit }}">
+                <i class="fa-solid fa-gear"></i> View In Admin
+            </a>
+            {% endif %}
         </menu>
     </div>
     {% endif %}


### PR DESCRIPTION
* Fixes styling on menu to keep `View Post & Replies` on a single line
* Adjust `z-index` of menu so it shows over post links of the next post
* Admins will see a "View In Admin" link for posts to quickly navigate to the admin for troubleshooting/intervention

![image](https://user-images.githubusercontent.com/30523/206029727-528b8b36-4969-441a-b42b-feb3e687eb07.png)
