### PR TITLE
Validate token scope and return 401 for invalid clients

### DIFF
--- a/api/decorators.py
+++ b/api/decorators.py
@@ -2,18 +2,31 @@ from functools import wraps
 
 from django.http import JsonResponse
 
+from api.models import has_required_scopes
 
-def identity_required(function):
+
+def scope_required(scope: str | None):
     """
     API version of the identity_required decorator that just makes sure the
-    token is tied to one, not an app only.
+    token is tied to an identity, not an app only.
     """
+    required_scopes = set(scope.split()) if scope else set()
 
-    @wraps(function)
-    def inner(request, *args, **kwargs):
-        # They need an identity
-        if not request.identity:
-            return JsonResponse({"error": "identity_token_required"}, status=400)
-        return function(request, *args, **kwargs)
+    def deco(function):
+        @wraps(function)
+        def inner(request, *args, **kwargs):
+            # They need an identity
+            if not request.identity:
+                return JsonResponse({"error": "identity_token_required"}, status=401)
+            if not has_required_scopes(
+                request.token_scopes or "read", required=required_scopes
+            ):
+                raise JsonResponse({"error": "invalid_token_scope"}, status=401)
+            return function(request, *args, **kwargs)
 
-    return inner
+        return inner
+
+    return deco
+
+
+identity_required = scope_required(scope=None)

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -23,5 +23,6 @@ class ApiTokenMiddleware:
             request.user = token.user
             request.identity = token.identity
             request.session = None
+            request.token_scopes = set(token.scopes)
         response = self.get_response(request)
         return response

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -1,2 +1,2 @@
 from .application import Application  # noqa
-from .token import Token  # noqa
+from .token import Token, has_required_scopes  # noqa

--- a/api/models/application.py
+++ b/api/models/application.py
@@ -17,3 +17,12 @@ class Application(models.Model):
 
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
+
+    def is_scope_subset(self, scopes: str) -> bool:
+        """
+        Return True if the scopes are a subset of this Application's scopes
+        """
+        app_scopes = set(filter(None, (self.scopes or "read").split()))
+        other_scopes = set(filter(None, scopes.split()))
+
+        return app_scopes & other_scopes == other_scopes

--- a/api/models/application.py
+++ b/api/models/application.py
@@ -17,12 +17,3 @@ class Application(models.Model):
 
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
-
-    def is_scope_subset(self, scopes: str) -> bool:
-        """
-        Return True if the scopes are a subset of this Application's scopes
-        """
-        app_scopes = set(filter(None, (self.scopes or "read").split()))
-        other_scopes = set(filter(None, scopes.split()))
-
-        return app_scopes & other_scopes == other_scopes

--- a/api/models/token.py
+++ b/api/models/token.py
@@ -1,5 +1,22 @@
 from django.db import models
 
+TokenScope = set[str] | str
+
+
+def has_required_scopes(scope: TokenScope, *, required: TokenScope) -> bool:
+    """
+    Returns True if scope contains all required scopes
+    """
+    if isinstance(scope, str):
+        scopes = set(scope.split())
+    else:
+        scopes = scope
+    if isinstance(required, str):
+        required_scopes = set(required.split())
+    else:
+        required_scopes = required or set()
+    return (scopes & required_scopes) == required_scopes
+
 
 class Token(models.Model):
     """

--- a/api/views/accounts.py
+++ b/api/views/accounts.py
@@ -2,7 +2,7 @@ from django.shortcuts import get_object_or_404
 
 from activities.models import Post, PostInteraction
 from api import schemas
-from api.decorators import identity_required
+from api.decorators import identity_required, scope_required
 from api.pagination import MastodonPaginator
 from api.views.base import api_router
 from users.models import Identity
@@ -15,7 +15,7 @@ def verify_credentials(request):
 
 
 @api_router.get("/v1/accounts/relationships", response=list[schemas.Relationship])
-@identity_required
+@scope_required("read")
 def account_relationships(request):
     ids = request.GET.getlist("id[]")
     result = []
@@ -46,14 +46,14 @@ def account_relationships(request):
 
 
 @api_router.get("/v1/accounts/{id}", response=schemas.Account)
-@identity_required
+@scope_required("read")
 def account(request, id: str):
     identity = get_object_or_404(Identity, pk=id)
     return identity.to_mastodon_json()
 
 
 @api_router.get("/v1/accounts/{id}/statuses", response=list[schemas.Status])
-@identity_required
+@scope_required("read")
 def account_statuses(
     request,
     id: str,

--- a/api/views/media.py
+++ b/api/views/media.py
@@ -7,7 +7,7 @@ from api import schemas
 from api.views.base import api_router
 from core.files import blurhash_image, resize_image
 
-from ..decorators import identity_required
+from ..decorators import scope_required
 
 
 class UploadMediaSchema(Schema):
@@ -17,7 +17,7 @@ class UploadMediaSchema(Schema):
 
 @api_router.post("/v1/media", response=schemas.MediaAttachment)
 @api_router.post("/v2/media", response=schemas.MediaAttachment)
-@identity_required
+@scope_required("write")
 def upload_media(
     request,
     file: UploadedFile = File(...),
@@ -54,7 +54,7 @@ def upload_media(
 
 
 @api_router.get("/v1/media/{id}", response=schemas.MediaAttachment)
-@identity_required
+@scope_required("read")
 def get_media(
     request,
     id: str,
@@ -64,7 +64,7 @@ def get_media(
 
 
 @api_router.put("/v1/media/{id}", response=schemas.MediaAttachment)
-@identity_required
+@scope_required("write")
 def update_media(
     request,
     id: str,

--- a/api/views/notifications.py
+++ b/api/views/notifications.py
@@ -1,12 +1,12 @@
 from activities.models import PostInteraction, TimelineEvent
 from api import schemas
-from api.decorators import identity_required
+from api.decorators import scope_required
 from api.pagination import MastodonPaginator
 from api.views.base import api_router
 
 
 @api_router.get("/v1/notifications", response=list[schemas.Notification])
-@identity_required
+@scope_required("read")
 def notifications(
     request,
     max_id: str | None = None,

--- a/api/views/oauth.py
+++ b/api/views/oauth.py
@@ -59,15 +59,6 @@ class AuthorizationView(LoginRequiredMixin, TemplateView):
                 status=401,
             )
 
-        if not application.is_scope_subset(scope):
-            return JsonResponse(
-                {
-                    "error": "invalid_scope",
-                    "error_description": "The requested scope is invalid, unknown, or malformed.",
-                },
-                status=400,
-            )
-
         # Get the identity
         identity = self.request.user.identities.get(pk=post_data["identity"])
 

--- a/api/views/search.py
+++ b/api/views/search.py
@@ -5,12 +5,12 @@ from ninja import Field
 from activities.models import PostInteraction
 from activities.search import Searcher
 from api import schemas
-from api.decorators import identity_required
+from api.decorators import scope_required
 from api.views.base import api_router
 
 
 @api_router.get("/v2/search", response=schemas.Search)
-@identity_required
+@scope_required("read")
 def search(
     request,
     q: str,

--- a/api/views/statuses.py
+++ b/api/views/statuses.py
@@ -15,7 +15,7 @@ from api import schemas
 from api.views.base import api_router
 from core.models import Config
 
-from ..decorators import identity_required
+from ..decorators import scope_required
 
 
 class PostStatusSchema(Schema):
@@ -30,7 +30,7 @@ class PostStatusSchema(Schema):
 
 
 @api_router.post("/v1/statuses", response=schemas.Status)
-@identity_required
+@scope_required("write")
 def post_status(request, details: PostStatusSchema):
     # Check text length
     if len(details.status) > Config.system.post_length:
@@ -67,7 +67,7 @@ def post_status(request, details: PostStatusSchema):
 
 
 @api_router.get("/v1/statuses/{id}", response=schemas.Status)
-@identity_required
+@scope_required("read")
 def status(request, id: str):
     post = get_object_or_404(Post, pk=id)
     interactions = PostInteraction.get_post_interactions([post], request.identity)
@@ -75,7 +75,7 @@ def status(request, id: str):
 
 
 @api_router.delete("/v1/statuses/{id}", response=schemas.Status)
-@identity_required
+@scope_required("write")
 def delete_status(request, id: str):
     post = get_object_or_404(Post, pk=id)
     post.transition_perform(PostStates.deleted)
@@ -84,7 +84,7 @@ def delete_status(request, id: str):
 
 
 @api_router.get("/v1/statuses/{id}/context", response=schemas.Context)
-@identity_required
+@scope_required("read")
 def status_context(request, id: str):
     post = get_object_or_404(Post, pk=id)
     parent = post.in_reply_to_post()
@@ -104,7 +104,7 @@ def status_context(request, id: str):
 
 
 @api_router.post("/v1/statuses/{id}/favourite", response=schemas.Status)
-@identity_required
+@scope_required("write")
 def favourite_status(request, id: str):
     post = get_object_or_404(Post, pk=id)
     post.like_as(request.identity)
@@ -113,7 +113,7 @@ def favourite_status(request, id: str):
 
 
 @api_router.post("/v1/statuses/{id}/unfavourite", response=schemas.Status)
-@identity_required
+@scope_required("write")
 def unfavourite_status(request, id: str):
     post = get_object_or_404(Post, pk=id)
     post.unlike_as(request.identity)
@@ -122,7 +122,7 @@ def unfavourite_status(request, id: str):
 
 
 @api_router.post("/v1/statuses/{id}/reblog", response=schemas.Status)
-@identity_required
+@scope_required("write")
 def reblog_status(request, id: str):
     post = get_object_or_404(Post, pk=id)
     post.boost_as(request.identity)
@@ -131,7 +131,7 @@ def reblog_status(request, id: str):
 
 
 @api_router.post("/v1/statuses/{id}/unreblog", response=schemas.Status)
-@identity_required
+@scope_required("write")
 def unreblog_status(request, id: str):
     post = get_object_or_404(Post, pk=id)
     post.unboost_as(request.identity)

--- a/api/views/timelines.py
+++ b/api/views/timelines.py
@@ -1,12 +1,12 @@
 from activities.models import Post, PostInteraction, TimelineEvent
 from api import schemas
-from api.decorators import identity_required
+from api.decorators import scope_required
 from api.pagination import MastodonPaginator
 from api.views.base import api_router
 
 
 @api_router.get("/v1/timelines/home", response=list[schemas.Status])
-@identity_required
+@scope_required("read")
 def home(
     request,
     max_id: str | None = None,
@@ -39,7 +39,7 @@ def home(
 
 
 @api_router.get("/v1/timelines/public", response=list[schemas.Status])
-@identity_required
+@scope_required("read")
 def public(
     request,
     local: bool = False,
@@ -75,7 +75,7 @@ def public(
 
 
 @api_router.get("/v1/timelines/tag/{hashtag}", response=list[schemas.Status])
-@identity_required
+@scope_required("read")
 def hashtag(
     request,
     hashtag: str,
@@ -112,7 +112,7 @@ def hashtag(
 
 
 @api_router.get("/v1/conversations", response=list[schemas.Status])
-@identity_required
+@scope_required("read")
 def conversations(
     request,
     max_id: str | None = None,

--- a/tests/api/test_oauth.py
+++ b/tests/api/test_oauth.py
@@ -1,11 +1,13 @@
-from api.models import Application
+from api.models import has_required_scopes
 
 
-def test_scope_subset():
-    app = Application(scopes="read")
-    assert app.is_scope_subset("read")
-    assert app.is_scope_subset("")
+def test_has_required_scopes():
+    assert has_required_scopes("read", required="")
+    assert has_required_scopes("read", required=None)
+    assert has_required_scopes("read", required="read")
+    assert has_required_scopes("read", required={"read"})
+    assert has_required_scopes({"read"}, required="read")
+    assert has_required_scopes({"read"}, required={"read"})
 
-    app.scopes = "read write follow push"
-    app.is_scope_subset("read write")
-    app.is_scope_subset("read push")
+    assert has_required_scopes("read write follow push", required="read write")
+    assert has_required_scopes("read write follow push", required="write push")

--- a/tests/api/test_oauth.py
+++ b/tests/api/test_oauth.py
@@ -1,0 +1,11 @@
+from api.models import Application
+
+
+def test_scope_subset():
+    app = Application(scopes="read")
+    assert app.is_scope_subset("read")
+    assert app.is_scope_subset("")
+
+    app.scopes = "read write follow push"
+    app.is_scope_subset("read write")
+    app.is_scope_subset("read push")


### PR DESCRIPTION
Pinafore.social got stuck in a broken state that I was able to clear by return 401s, instead of 400s when the client_id was invalid. This matches the mastodon docs https://docs.joinmastodon.org/methods/oauth/#401-unauthorized

Also added token scope comparison.