### PR TITLE
Several pagination improvements

### DIFF
--- a/activities/views/follows.py
+++ b/activities/views/follows.py
@@ -1,8 +1,10 @@
+from django.core.paginator import Paginator
+from django.db.models import Q
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
 from users.decorators import identity_required
-from users.models import FollowStates
+from users.models import Follow, FollowStates
 
 
 @method_decorator(identity_required, name="dispatch")
@@ -15,19 +17,25 @@ class FollowsPage(TemplateView):
 
     def get_context_data(self):
         # Gather all identities with a following relationship with us
-        identities = {}
-        for outbound_follow in self.request.identity.outbound_follows.filter(
-            state__in=FollowStates.group_active()
-        ):
-            identities.setdefault(outbound_follow.target, {})[
-                "outbound"
-            ] = outbound_follow
-        for inbound_follow in self.request.identity.inbound_follows.filter(
-            state__in=FollowStates.group_active()
-        ):
-            identities.setdefault(inbound_follow.source, {})["inbound"] = inbound_follow
+        follows = Follow.objects.filter(
+            Q(source=self.request.identity) | Q(target=self.request.identity),
+            state__in=FollowStates.group_active(),
+        ).order_by("-id")
+        paginator = Paginator(follows, 50)
+        page_number = self.request.GET.get("page")
+        page_obj = paginator.get_page(page_number)
+        identities = []
+        for follow in page_obj.object_list:
+            if follow.source == self.request.identity:
+                identity = follow.target
+                follow_type = "outbound"
+            else:
+                identity = follow.source
+                follow_type = "inbound"
+            identities.append((identity, follow_type))
+        page_obj.object_list = identities
 
         return {
             "section": "follows",
-            "identities": sorted(identities.items(), key=lambda i: i[0].username),
+            "page_obj": page_obj,
         }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1079,6 +1079,12 @@ table.metadata td .emoji {
     margin-right: 4px;
 }
 
+.pagination {
+    display: flex;
+    justify-content: center;
+    gap: 1em;
+}
+
 .load-more {
     margin: 10px 0;
     text-align: center;

--- a/takahe/urls.py
+++ b/takahe/urls.py
@@ -23,7 +23,7 @@ urlpatterns = [
     path("explore/tags/", explore.ExploreTag.as_view(), name="explore-tag"),
     path(
         "follows/",
-        follows.FollowsPage.as_view(),
+        follows.Follows.as_view(),
         name="follows",
     ),
     # Settings views

--- a/templates/activities/follows.html
+++ b/templates/activities/follows.html
@@ -4,17 +4,17 @@
 
 {% block content %}
     <section class="icon-menu">
-        {% for identity, details in identities %}
+        {% for identity, follow_type in page_obj %}
             <a class="option" href="{{ identity.urls.view }}">
                 <img src="{{ identity.local_icon_url.relative }}">
                 <span class="handle">
                     {{ identity.html_name_or_handle }}
                     <small>@{{ identity.handle }}</small>
                 </span>
-                {% if details.outbound %}
+                {% if follow_type == "outbound" %}
                     <span class="pill">Following</span>
                 {% endif %}
-                {% if details.inbound %}
+                {% if follow_type == "inbound" %}
                     <span class="pill">Follows You</span>
                 {% endif %}
             </a>
@@ -22,4 +22,14 @@
             <p class="option empty">You have no follows.</p>
         {% endfor %}
     </section>
+
+    <div class="pagination">
+        {% if page_obj.has_previous %}
+            <div class="load-more"><a class="button" href=".?page={{ page_obj.previous_page_number }}">Previous Page</a></div>
+        {% endif %}
+
+        {% if page_obj.has_next %}
+            <div class="load-more"><a class="button" href=".?page={{ page_obj.next_page_number }}">Next Page</a></div>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/templates/activities/home.html
+++ b/templates/activities/home.html
@@ -4,7 +4,7 @@
 {% block title %}Home{% endblock %}
 
 {% block content %}
-    {% for event in events %}
+    {% for event in page_obj %}
         {% if event.type == "post" %}
             {% include "activities/_post.html" with post=event.subject_post %}
         {% elif event.type == "boost" %}
@@ -21,4 +21,14 @@
     {% empty %}
         Nothing to show yet.
     {% endfor %}
+
+    <div class="pagination">
+        {% if page_obj.has_previous %}
+            <div class="load-more"><a class="button" href=".?page={{ page_obj.previous_page_number }}">Previous Page</a></div>
+        {% endif %}
+
+        {% if page_obj.has_next %}
+            <div class="load-more"><a class="button" href=".?page={{ page_obj.next_page_number }}">Next Page</a></div>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/templates/activities/local.html
+++ b/templates/activities/local.html
@@ -9,7 +9,13 @@
         No posts yet.
     {% endfor %}
 
-    {% if page_obj.has_next %}
-        <div class="load-more"><a class="button" href=".?page={{ page_obj.next_page_number }}">Next Page</a></div>
-    {% endif %}
+    <div class="pagination">
+        {% if page_obj.has_previous %}
+            <div class="load-more"><a class="button" href=".?page={{ page_obj.previous_page_number }}">Previous Page</a></div>
+        {% endif %}
+
+        {% if page_obj.has_next %}
+            <div class="load-more"><a class="button" href=".?page={{ page_obj.next_page_number }}">Next Page</a></div>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/templates/activities/notifications.html
+++ b/templates/activities/notifications.html
@@ -32,7 +32,13 @@
         No notifications yet.
     {% endfor %}
 
-    {% if page_obj.has_next %}
-        <div class="load-more"><a class="button" href=".?page={{ page_obj.next_page_number }}">Next Page</a></div>
-    {% endif %}
+    <div class="pagination">
+        {% if page_obj.has_previous %}
+            <div class="load-more"><a class="button" href=".?page={{ page_obj.previous_page_number }}">Previous Page</a></div>
+        {% endif %}
+
+        {% if page_obj.has_next %}
+            <div class="load-more"><a class="button" href=".?page={{ page_obj.next_page_number }}">Next Page</a></div>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/templates/activities/tag.html
+++ b/templates/activities/tag.html
@@ -10,7 +10,13 @@
         No posts yet.
     {% endfor %}
 
-    {% if page_obj.has_next %}
-        <div class="load-more"><a class="button" href=".?page={{ page_obj.next_page_number }}">Next Page</a></div>
-    {% endif %}
+    <div class="pagination">
+        {% if page_obj.has_previous %}
+            <div class="load-more"><a class="button" href=".?page={{ page_obj.previous_page_number }}">Previous Page</a></div>
+        {% endif %}
+
+        {% if page_obj.has_next %}
+            <div class="load-more"><a class="button" href=".?page={{ page_obj.next_page_number }}">Next Page</a></div>
+        {% endif %}
+    </div>
 {% endblock %}


### PR DESCRIPTION
This PR adds pagination to the Home timeline and the Follows page.

A couple of caveats:

* The Follows were ordered by the username, but we can't do that efficiently now without traversing the whole unpaginated queryset (which would defeat the purpose of pagination). They're now ordered by `id`, which _should_ equate to creation order.
* I removed a lot of slices in the paginated querysets. I don't know if those were deliberate or leftovers from before pagination was added.
* I added buttons to go back to previous pages. Again, I don't know if that omission was deliberate.

Fixes  #126 and partially fixes #168.