### PR TITLE
Set the correct `Content-Type` header for static WebP images

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -4,6 +4,7 @@ from django.templatetags.static import static
 from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
 from django.views.generic import TemplateView, View
+from django.views.static import serve
 
 from activities.views.timelines import Home
 from core.decorators import cache_page
@@ -89,3 +90,14 @@ class FlatPage(TemplateView):
             "title": self.title,
             "content": mark_safe(html),
         }
+
+
+def custom_static_serve(*args, **keywords):
+    """
+    Set the correct `Content-Type` header for static WebP images
+    since Django cannot guess the MIME type of WebP images.
+    """
+    response = serve(*args, **keywords)
+    if keywords["path"].endswith(".webp"):
+        response.headers["Content-Type"] = "image/webp"
+    return response

--- a/takahe/urls.py
+++ b/takahe/urls.py
@@ -1,7 +1,6 @@
 from django.conf import settings as djsettings
 from django.contrib import admin as djadmin
 from django.urls import path, re_path
-from django.views.static import serve
 
 from activities.views import compose, explore, follows, posts, search, timelines
 from api.views import api_router, oauth
@@ -219,7 +218,7 @@ urlpatterns = [
     # Media files
     re_path(
         r"^media/(?P<path>.*)$",
-        serve,
+        core.custom_static_serve,
         kwargs={"document_root": djsettings.MEDIA_ROOT},
     ),
 ]


### PR DESCRIPTION
This is a simiar fix as #163 but for the local WebP image serving. Previously, `content-deposition` has already been set to `inline` by Django, but `content-type` was `application/octet-stream`, which was causing downloading.

It can be implemented by customizing the original `django.views.static.serve` view for `*.webp` files.

## Reason for custom view

The reason why we cannot use the original `serve` is that [the current Django implementation](https://cs.github.com/django/django/blob/09ffc5c1212d4ced58b708cbbf3dfbfb77b782ca/django/http/response.py#L558) set the `Content-Type` header based on the return value of `mimetypes.guess_type()`. Although the `image/webp` MIME type has been added to `mimetypes` database just since Python 3.11 (ref. python/cpython#29259), the `image/webp` is not yet registered to [the official IANA mime-type list](https://www.iana.org/assignments/media-types/media-types.xhtml) and `guess_type()` in the Django source code needs to have `strict=False` option to guess `image/webp`, but it doesn't.

## Screenshot after this change
<img width="1335" alt="Screenshot 2022-12-16 at 1 18 26" src="https://user-images.githubusercontent.com/1425259/207918487-007662a0-ae21-45fb-a8f1-3161f036addd.png">

<img width="1281" alt="Screenshot 2022-12-16 at 1 17 57" src="https://user-images.githubusercontent.com/1425259/207918477-55cad7f3-2a0b-4b1f-8462-b6e868fc8204.png">
