### PR TITLE
Mitra Fixes

### DIFF
--- a/core/html.py
+++ b/core/html.py
@@ -20,7 +20,7 @@ def sanitize_post(post_html: str) -> str:
     Only allows a, br, p and span tags, and class attributes.
     """
     cleaner = bleach.Cleaner(
-        tags=["br", "p"],
+        tags=["br", "p", "a"],
         attributes={  # type:ignore
             "a": allow_a,
             "p": ["class"],

--- a/core/signatures.py
+++ b/core/signatures.py
@@ -200,7 +200,7 @@ class HttpSignature:
             body_bytes = b""
         # GET requests get implicit accept headers added
         if method == "get":
-            headers["Accept"] = "application/activity+json, application/ld+json"
+            headers["Accept"] = "application/activity+json"
         # Sign the headers
         signed_string = "\n".join(
             f"{name.lower()}: {value}" for name, value in headers.items()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@ ARG IMAGE_LABEL=3.11.1-slim-buster
 
 FROM ${IMAGE_HOST}:${IMAGE_LABEL}
 
+ENV PYTHONUNBUFFERED=1
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libpq5 \


### PR DESCRIPTION
Mitra has a bug in its handling of the `Accept` header (https://f.tkte.ch/@tktech@tkte.ch/posts/13530/) and this change doesn't seem to affect any of the existing servers.  This fixes search-by-url breaking on Mitra because it would return HTML on /post/ URLs instead of redirecting them to /objects/.

Re-allows `<a>` in posts, which was (accidentally?) removed in https://github.com/jointakahe/takahe/commit/2a3690d1c148da5dd799052403ba7290e1fb7de0.