### PR TITLE
Stop saving infinite files.

### DIFF
--- a/core/uploads.py
+++ b/core/uploads.py
@@ -23,10 +23,7 @@ def upload_namer(prefix, instance, filename):
         # If we're saving images for an Identity, we only keep the most recently
         # received. Ideally, we should hash the file content and de-duplicate
         # but this is the easy and immediate solution.
-        return (
-            f"{prefix}/"
-            f"{urllib.parse.quote(instance.handle)}{old_extension}"
-        )
+        return f"{prefix}/{urllib.parse.quote(instance.handle)}{old_extension}"
 
     new_filename = secrets.token_urlsafe(20)
     now = timezone.now()

--- a/core/uploads.py
+++ b/core/uploads.py
@@ -1,5 +1,6 @@
 import os
 import secrets
+import urllib.parse
 from typing import TYPE_CHECKING
 
 from django.utils import timezone
@@ -12,11 +13,23 @@ if TYPE_CHECKING:
 
 def upload_namer(prefix, instance, filename):
     """
-    Names uploaded images, obscuring their original name with a random UUID.
+    Names uploaded images.
+
+    By default, obscures the original name with a random UUID.
     """
-    now = timezone.now()
     _, old_extension = os.path.splitext(filename)
+
+    if prefix == "profile_images":
+        # If we're saving images for an Identity, we only keep the most recently
+        # received. Ideally, we should hash the file content and de-duplicate
+        # but this is the easy and immediate solution.
+        return (
+            f"{prefix}/"
+            f"{urllib.parse.quote(instance.handle)}{old_extension}"
+        )
+
     new_filename = secrets.token_urlsafe(20)
+    now = timezone.now()
     return f"{prefix}/{now.year}/{now.month}/{now.day}/{new_filename}{old_extension}"
 
 


### PR DESCRIPTION
Use a consistent name for Identity.icon as a quick fix to stop flooding object storage. Right now, an Identity is considered outdated after 1 hour. Every hour, it fetches the account avatar and _assigns to identity.icon_, which keeps the old object and uploads a new one. If you've got a 100 identities, after a day you have 2400 avatars. This is the cause of the ridiculously large S3 buckets.