### PR TITLE
Minor design tweaks to the Follows page

### DIFF
--- a/activities/views/follows.py
+++ b/activities/views/follows.py
@@ -63,7 +63,9 @@ class Follows(ListView):
             )
             identity_ids = [identity.id for identity in context["page_obj"]]
             context["outbound_ids"] = Follow.objects.filter(
-                source=self.request.identity, target_id__in=identity_ids
+                source=self.request.identity,
+                target_id__in=identity_ids,
+                state__in=FollowStates.group_active(),
             ).values_list("target_id", flat=True)
         else:
             context["page_obj"].object_list = self.follows_to_identities(
@@ -71,7 +73,9 @@ class Follows(ListView):
             )
             identity_ids = [identity.id for identity in context["page_obj"]]
             context["inbound_ids"] = Follow.objects.filter(
-                target=self.request.identity, source_id__in=identity_ids
+                target=self.request.identity,
+                source_id__in=identity_ids,
+                state__in=FollowStates.group_active(),
             ).values_list("source_id", flat=True)
         context["inbound"] = self.inbound
         context["num_inbound"] = Follow.objects.filter(

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -414,10 +414,11 @@ img.emoji {
 
 .icon-menu .option .pill {
     display: inline-block;
-    padding: 5px 8px;
-    background: var(--color-highlight);
-    border-radius: 5px;
+    padding: 2px 10px;
+    background: var(--color-text-duller);
+    border-radius: 20px;
     margin: 0 5px 0 5px;
+    font-size: 70%;
 }
 
 .icon-menu .option .pill.bad {
@@ -428,6 +429,16 @@ img.emoji {
     float: right;
     color: var(--color-text-duller);
     margin: 14px 0 0 0;
+}
+
+.icon-menu .option .right {
+    display: inline-block;
+    float: right;
+}
+
+.icon-menu .option button {
+    margin-top: 8px;
+    margin-right: 20px;
 }
 
 .handle {
@@ -466,24 +477,28 @@ form.inline {
     padding: 0;
 }
 
-form.follow {
+form.follow-profile {
     float: right;
     margin: 20px 0 0 0;
     font-size: 16px;
     text-align: center;
 }
 
-form.follow.has-reverse {
+form.follow-profile.has-reverse {
     margin-top: 0;
 }
 
-form.follow .reverse-follow {
+form.follow-profile .reverse-follow {
     display: block;
     margin: 0 0 5px 0;
 }
 
-form.follow button {
+form.follow-profile button {
     margin: 0;
+}
+
+form.follow {
+    display: inline;
 }
 
 form.search {
@@ -721,6 +736,11 @@ button.danger,
     background: var(--color-delete);
 }
 
+button.destructive:hover,
+.button.destructive:hover {
+    background: var(--color-delete);
+}
+
 button.secondary,
 .button.secondary {
     background: var(--color-bg-menu);
@@ -889,14 +909,22 @@ table.metadata td .emoji {
 
 .view-options a {
     margin: 0 10px 0 0;
-    padding: 4px 7px;
+    padding: 4px 12px;
     color: var(--color-text-duller);
     background: var(--color-bg-box);
     border-radius: 3px;
 }
 
+.view-options a:hover {
+    background: var(--color-text-dull);
+}
+
 .view-options a.selected {
-    color: var(--color-text-main);
+    color: var(--color-text-highlight);
+}
+
+.view-options .fa-solid {
+    min-width: 16px;
 }
 
 /* Posts */

--- a/templates/activities/follows.html
+++ b/templates/activities/follows.html
@@ -22,13 +22,30 @@
                     {{ identity.html_name_or_handle }}
                     <small>@{{ identity.handle }}</small>
                 </span>
+
                 {% if identity.id in outbound_ids %}
                     <span class="pill">Following</span>
                 {% endif %}
                 {% if identity.id in inbound_ids %}
                     <span class="pill">Follows You</span>
                 {% endif %}
-                <time>{{ identity.follow_date | timedeltashort }} ago</time>
+
+                <div class="right">
+                    {% if inbound %}
+                      <form action="{{ identity.urls.action }}" method="POST" class="follow">
+                          {% csrf_token %}
+                          {% if identity.id in outbound_ids %}
+                              <input type="hidden" name="action" value="unfollow">
+                              <button class="destructive">Unfollow</button>
+                          {% else %}
+                              <input type="hidden" name="action" value="follow">
+                              <button>Follow</button>
+                          {% endif %}
+                      </form>
+                    {% endif %}
+
+                    <time>{{ identity.follow_date | timedeltashort }} ago</time>
+                </div>
             </a>
         {% empty %}
             <p class="option empty">You have no follows.</p>

--- a/templates/identity/view.html
+++ b/templates/identity/view.html
@@ -76,7 +76,7 @@
       <div class="stats">
         <ul>
           <li><strong>{{ following_count }}</strong> following</li>
-          <li><strong>{{ followers_count }}</strong> followers</li>
+          <li><strong>{{ followers_count }}</strong> follower{{ followers_count|pluralize }}</li>
         </ul>
       </div>
     {% endif %}

--- a/templates/identity/view.html
+++ b/templates/identity/view.html
@@ -24,14 +24,14 @@
                     <a class="button" href="{% url "settings_profile" %}">Edit Profile</a>
                 </form>
             {% else %}
-                <form action="{{ identity.urls.action }}" method="POST" class="inline follow {% if reverse_follow %}has-reverse{% endif %}">
+                <form action="{{ identity.urls.action }}" method="POST" class="inline follow-profile {% if reverse_follow %}has-reverse{% endif %}">
                     {% csrf_token %}
                     {% if reverse_follow %}
                         <span class="reverse-follow">Follows You</span>
                     {% endif %}
                     {% if follow %}
                         <input type="hidden" name="action" value="unfollow">
-                        <button>Unfollow</button>
+                        <button class="destructive">Unfollow</button>
                     {% else %}
                         <input type="hidden" name="action" value="follow">
                         <button>Follow</button>

--- a/tests/users/views/settings/test_privacy.py
+++ b/tests/users/views/settings/test_privacy.py
@@ -13,7 +13,7 @@ def test_stats(client, identity, other_identity):
     Follow.objects.create(source=other_identity, target=identity)
     Config.set_identity(identity, "visible_follows", True)
     response = client.get(identity.urls.view)
-    assertContains(response, "<strong>1</strong> followers", status_code=200)
+    assertContains(response, "<strong>1</strong> follower", status_code=200)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR fixes the follow list showing the "Following"/"Follows You" pill for inactive follows too.

Since I was at it, I also made a few design tweaks. They're all debatable, so tell me what do you think:

* Change pill appearance to distinguish it from buttons
  
  <img src="https://user-images.githubusercontent.com/289617/208969427-797b6147-eafc-46c0-bf24-d97494e5a8e0.png" width="50%">

* Add follow/unfollow buttons to the Follows list

  <img src="https://user-images.githubusercontent.com/289617/208971662-791af510-fd99-4609-821e-7f26436c9cbf.png" width="50%">

* Signal destructive action when hovering unfollow buttons

  <img src="https://user-images.githubusercontent.com/289617/208969706-bcc95bd1-da9f-4800-beea-20fdaa5c9916.png" width="50%">

* Add hover style to the top "tabs"/"filters"
  
  <img src="https://user-images.githubusercontent.com/289617/208969862-702fc205-8f67-4064-9fe6-33694665b0f5.png" width="50%">

* Make filters icon have the same width so selecting them doesn't change
  the options total width, which is mildly unnerving

[Screencast from 2022-12-21 18-48-14.webm](https://user-images.githubusercontent.com/289617/208971239-8f3e5b48-10d6-4aa5-8df6-292284f3bc92.webm)

[Screencast from 2022-12-21 18-46-30.webm](https://user-images.githubusercontent.com/289617/208971178-b87be3fa-7ea6-406a-b798-b76b110d9259.webm)