### PR TITLE
Include long form and shortform aliases in webfinger 

### DIFF
--- a/users/models/system_actor.py
+++ b/users/models/system_actor.py
@@ -21,6 +21,7 @@ class SystemActor:
         self.public_key_id = self.actor_uri + "#main-key"
         self.profile_uri = f"https://{settings.MAIN_DOMAIN}/about/"
         self.username = "__system__"
+        self.handle = f"__system__@{settings.MAIN_DOMAIN}"
 
     def absolute_profile_uri(self):
         return self.profile_uri
@@ -56,6 +57,26 @@ class SystemActor:
                 "owner": self.actor_uri,
                 "publicKeyPem": self.public_key,
             },
+        }
+
+    def to_webfinger(self):
+        return {
+            "subject": f"acct:{self.handle}",
+            "aliases": [
+                self.absolute_profile_uri(),
+            ],
+            "links": [
+                {
+                    "rel": "http://webfinger.net/rel/profile-page",
+                    "type": "text/html",
+                    "href": self.absolute_profile_uri(),
+                },
+                {
+                    "rel": "self",
+                    "type": "application/activity+json",
+                    "href": self.actor_uri,
+                },
+            ],
         }
 
     async def signed_request(

--- a/users/views/activitypub.py
+++ b/users/views/activitypub.py
@@ -108,28 +108,8 @@ class Webfinger(View):
             actor = SystemActor()
         else:
             actor = by_handle_or_404(request, handle)
-            handle = actor.handle
 
-        return JsonResponse(
-            {
-                "subject": f"acct:{handle}",
-                "aliases": [
-                    actor.absolute_profile_uri(),
-                ],
-                "links": [
-                    {
-                        "rel": "http://webfinger.net/rel/profile-page",
-                        "type": "text/html",
-                        "href": actor.absolute_profile_uri(),
-                    },
-                    {
-                        "rel": "self",
-                        "type": "application/activity+json",
-                        "href": actor.actor_uri,
-                    },
-                ],
-            }
-        )
+        return JsonResponse(actor.to_webfinger())
 
 
 @method_decorator(csrf_exempt, name="dispatch")


### PR DESCRIPTION
Some servers are stricter about verifying actors. Adding both the long form and short form fixes the errors I've run in to with them.