### PR TITLE
Handle more also_known_as scenarios

### DIFF
--- a/takahe/urls.py
+++ b/takahe/urls.py
@@ -163,6 +163,10 @@ urlpatterns = [
     path("@<handle>/report/", report.SubmitReport.as_view()),
     path("@<handle>/following/", identity.IdentityFollows.as_view(inbound=False)),
     path("@<handle>/followers/", identity.IdentityFollows.as_view(inbound=True)),
+    re_path(
+        r"^users?/(?P<handle>[a-zA-Z0-9_-].*)/?$",
+        identity.ViewIdentityAlt.as_view(),
+    ),
     # Posts
     path("compose/", compose.Compose.as_view(), name="compose"),
     path(

--- a/users/admin.py
+++ b/users/admin.py
@@ -40,18 +40,22 @@ class IdentityAdmin(admin.ModelAdmin):
     list_display = ["id", "handle", "actor_uri", "state", "local"]
     list_filter = ("local", "state", "discoverable")
     raw_id_fields = ["users"]
-    actions = ["force_update"]
-    readonly_fields = ["actor_json"]
+    actions = ["force_state_outdated"]
+    readonly_fields = ["actor_json", "webfinger_json"]
     search_fields = ["username", "name"]
 
-    @admin.action(description="Force Update")
-    def force_update(self, request, queryset):
+    @admin.action(description="Force State: outdated")
+    def force_state_outdated(self, request, queryset):
         for instance in queryset:
             instance.transition_perform("outdated")
 
     @admin.display(description="ActivityPub JSON")
     def actor_json(self, instance):
         return instance.to_ap()
+
+    @admin.display(description="Webfinger JSON")
+    def webfinger_json(self, instance):
+        return instance.to_webfinger()
 
     def has_add_permission(self, request, obj=None):
         return False


### PR DESCRIPTION
Acquired Domains:

* Handle "/user/{username}" and "/users/{username}" for any Domain.local
* Domain.local must exist and an Identity must have also_known_as.
* Identity.domain doesn't need to match the matched local Domain

Incorrect actor_uri:

Commit #578b504c924176e66531cd0ce64120de65e80c7a added the short form actor_uri as a webfinger alias, but InboxMessage only supports lookup by actor_uri. This adds also_known_as lookups in fetch_actor with Sentry messaging when conflicts are found.