### PR TITLE
Identity background images can be relative

### DIFF
--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -276,7 +276,7 @@ class Identity(StatorModel):
         Returns a background image for us, returning None if there isn't one
         """
         if self.image:
-            return RelativeAbsoluteUrl(self.image.url)
+            return AutoAbsoluteUrl(self.image.url)
         elif self.image_uri:
             return AutoAbsoluteUrl(f"/proxy/identity_image/{self.pk}/")
         return None


### PR DESCRIPTION
Fixes the surprise server profile bomb for those using local media storage.