### PR TITLE
Simple user stylesheet support.

### DIFF
--- a/core/models/config.py
+++ b/core/models/config.py
@@ -246,3 +246,5 @@ class Config(models.Model):
 
         # wellness Options
         visible_reaction_counts: bool = True
+
+        custom_css: str | None

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,9 @@
         }
         {% endif %}
     </style>
+    {% if config_identity.custom_css %}
+      <style>{{ config_identity.custom_css }}</style>
+    {% endif %}
     {% block extra_head %}{% endblock %}
 </head>
 <body class="{% block body_class %}{% endblock %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>

--- a/users/views/settings/interface.py
+++ b/users/views/settings/interface.py
@@ -20,9 +20,15 @@ class InterfacePage(SettingsPage):
             "title": "Show Boost and Like Counts",
             "help_text": "Disable to hide the number of Likes and Boosts on a 'Post'",
         },
+        "custom_css": {
+            "title": "Custom CSS",
+            "help_text": "Theme the website however you'd like, just for you. You should probably not use this unless you know what you're doing.",
+            "display": "textarea",
+        },
     }
 
     layout = {
         "Posting": ["toot_mode", "default_post_visibility"],
         "Wellness": ["visible_reaction_counts"],
+        "Appearance": ["custom_css"],
     }


### PR DESCRIPTION
This simple change lets users specify custom CSS to theme the look of their takahe profile. It is _100%_ unsafe to allow this for other users, so this is and will always be only for the user's own identity only.