### PR TITLE
Basic OpenGraph support

### DIFF
--- a/activities/models/post.py
+++ b/activities/models/post.py
@@ -832,7 +832,7 @@ class Post(StatorModel):
 
     ### OpenGraph API ###
 
-    def to_opengraph_dict(self):
+    def to_opengraph_dict(self) -> dict:
         return {
             "og:title": f"{self.author.name} (@{self.author.handle})",
             "og:type": "article",

--- a/activities/models/post.py
+++ b/activities/models/post.py
@@ -830,6 +830,22 @@ class Post(StatorModel):
                 raise ValueError("Actor on delete does not match object")
             post.delete()
 
+    ### OpenGraph API ###
+
+    def to_opengraph_dict(self):
+        return {
+            "og:title": f"{self.author.name} (@{self.author.handle})",
+            "og:type": "article",
+            "og:published_time": (self.published or self.created).isoformat(),
+            "og:modified_time": (
+                self.edited or self.published or self.created
+            ).isoformat(),
+            "og:description": (self.summary or self.safe_content_local()),
+            "og:image:url": self.author.local_icon_url().absolute,
+            "og:image:height": 85,
+            "og:image:width": 85,
+        }
+
     ### Mastodon API ###
 
     def to_mastodon_json(self, interactions=None):

--- a/activities/templatetags/opengraph.py
+++ b/activities/templatetags/opengraph.py
@@ -1,0 +1,23 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def dict_merge(base: dict, defaults: dict):
+    """
+    Merges two input dictionaries, returning the merged result.
+
+    `input|dict_merge:defaults`
+
+    The defaults are overridden by any key present in the `input` dict.
+    """
+    if not (isinstance(base, dict) or isinstance(defaults, dict)):
+        raise ValueError("Filter inputs must be dictionaries")
+
+    result = {}
+
+    result.update(defaults)
+    result.update(base)
+
+    return result

--- a/activities/views/posts.py
+++ b/activities/views/posts.py
@@ -42,8 +42,6 @@ class Individual(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context["opengraph"] = self.post_obj.to_opengraph_dict()
-
         ancestors, descendants = PostService(self.post_obj).context(
             self.request.identity
         )

--- a/activities/views/posts.py
+++ b/activities/views/posts.py
@@ -57,13 +57,19 @@ class Individual(TemplateView):
             "opengraph": {
                 "title": f"{self.post_obj.author.name} (@{self.post_obj.author.handle})",
                 "type": "article",
-                "published_time": self.post_obj.published.isoformat()
-                or self.post_obj.created.isoformat(),
-                "modified_time": self.post_obj.edited.isoformat()
-                or self.post_obj.published.isoformat()
-                or self.post_obj.created.isoformat(),
-                "description": self.post_obj.summary
-                or bleach.clean(self.post_obj.safe_content_local(), strip=True),
+                "published_time": (
+                    self.post_obj.published.isoformat()
+                    or self.post_obj.created.isoformat()
+                ),
+                "modified_time": (
+                    self.post_obj.edited.isoformat()
+                    or self.post_obj.published.isoformat()
+                    or self.post_obj.created.isoformat()
+                ),
+                "description": (
+                    self.post_obj.summary
+                    or bleach.clean(self.post_obj.safe_content_local(), strip=True)
+                ),
                 "image": {
                     "url": self.post_obj.author.local_icon_url().absolute,
                     "height": 85,

--- a/activities/views/posts.py
+++ b/activities/views/posts.py
@@ -1,4 +1,3 @@
-import bleach
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -67,8 +66,7 @@ class Individual(TemplateView):
                     or self.post_obj.created.isoformat()
                 ),
                 "description": (
-                    self.post_obj.summary
-                    or bleach.clean(self.post_obj.safe_content_local(), strip=True)
+                    self.post_obj.summary or self.post_obj.safe_content_local()
                 ),
                 "image": {
                     "url": self.post_obj.author.local_icon_url().absolute,

--- a/activities/views/posts.py
+++ b/activities/views/posts.py
@@ -1,3 +1,4 @@
+import bleach
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -53,6 +54,22 @@ class Individual(TemplateView):
             "link_original": True,
             "ancestors": ancestors,
             "descendants": descendants,
+            "opengraph": {
+                "title": f"{self.post_obj.author.name} (@{self.post_obj.author.handle})",
+                "type": "article",
+                "published_time": self.post_obj.published.isoformat()
+                or self.post_obj.created.isoformat(),
+                "modified_time": self.post_obj.edited.isoformat()
+                or self.post_obj.published.isoformat()
+                or self.post_obj.created.isoformat(),
+                "description": self.post_obj.summary
+                or bleach.clean(self.post_obj.safe_content_local(), strip=True),
+                "image": {
+                    "url": self.post_obj.author.local_icon_url().absolute,
+                    "height": 85,
+                    "width": 85,
+                },
+            },
         }
 
     def serve_object(self):

--- a/core/context.py
+++ b/core/context.py
@@ -8,8 +8,7 @@ def config_context(request):
             request.identity.config_identity if request.identity else None
         ),
         "top_section": request.path.strip("/").split("/")[0],
-        # THIS DOESN'T WORK
-        "opengraph": {
+        "opengraph_default": {
             "og:site_name": Config.system.site_name,
             "og:type": "website",
             "og:title": Config.system.site_name,

--- a/core/context.py
+++ b/core/context.py
@@ -8,4 +8,11 @@ def config_context(request):
             request.identity.config_identity if request.identity else None
         ),
         "top_section": request.path.strip("/").split("/")[0],
+        # THIS DOESN'T WORK
+        "opengraph": {
+            "og:site_name": Config.system.site_name,
+            "og:type": "website",
+            "og:title": Config.system.site_name,
+            "og:url": request.build_absolute_uri(),
+        },
     }

--- a/core/context.py
+++ b/core/context.py
@@ -8,7 +8,7 @@ def config_context(request):
             request.identity.config_identity if request.identity else None
         ),
         "top_section": request.path.strip("/").split("/")[0],
-        "opengraph_default": {
+        "opengraph_defaults": {
             "og:site_name": Config.system.site_name,
             "og:type": "website",
             "og:title": Config.system.site_name,

--- a/templates/_opengraph.html
+++ b/templates/_opengraph.html
@@ -1,0 +1,32 @@
+{% if opengraph.disabled %}
+    <!-- OpenGraph tagging disabled on this page -->
+{% else %}
+{% block opengraph %}
+    <!-- Begin OpenGraph tagging -->
+    <meta content="{{ config.site_name }}" property="og:site_name"/>
+    <meta content="{{ opengraph.type|default:"website" }}" property="og:type"/>
+    <meta content="{{ opengraph.title|default:config.site_name }}" property="og:title"/>
+    <meta content="{{ opengraph.url|default:request.build_absolute_uri }}" property="og:url"/>
+    {% if opengraph.published_time %}
+        <meta content="{{ opengraph.published_time }}" property="og:published_time"/>
+    {% endif %}
+    {% if opengraph.modifed_time %}
+        <meta content="{{ opengraph.modifed_time }}" property="og:modifed_time"/>
+    {% endif %}
+    {% if opengraph.description %}
+        <meta content="{{ opengraph.description }}" property="og:description"/>
+    {% endif %}
+    {% if opengraph.profile.username %}
+        <meta content="{{ opengraph.profile.username }}" property="og:profile:username"/>
+    {% endif %}
+    <meta content="{{ opengraph.image.url|default:config.site_icon }}" property="og:image"/>
+    <meta content="{{ opengraph.image.type|default:"image/webp" }}" property="og:image:type"/>
+    {% if opengraph.image.width %}
+        <meta content="{{ opengraph.image.width }}" property="og:image:width" />
+        <meta content="{{ opengraph.image.height }}" property="og:image:height" />
+    {% endif %}
+    {% block opengraph_extra %}
+    {% endblock %}
+    <!-- End OpenGraph tagging -->
+{% endblock %}
+{% endif %}

--- a/templates/_opengraph.html
+++ b/templates/_opengraph.html
@@ -3,34 +3,15 @@
 {% else %}
 {% block opengraph %}
     <!-- Begin OpenGraph tagging -->
-    <meta content="{{ config.site_name }}" property="og:site_name"/>
-    <meta content="{{ opengraph.type|default:"website" }}" property="og:type"/>
-    <meta content="{{ opengraph.title|default:config.site_name }}" property="og:title"/>
-    <meta content="{{ opengraph.url|default:request.build_absolute_uri }}" property="og:url"/>
-    {% if opengraph.published_time %}
-        <meta content="{{ opengraph.published_time }}" property="og:published_time"/>
-    {% endif %}
-    {% if opengraph.modifed_time %}
-        <meta content="{{ opengraph.modifed_time }}" property="og:modifed_time"/>
-    {% endif %}
-    {% if opengraph.description %}
-        <meta content="{{ opengraph.description|striptags }}" property="og:description"/>
-        <meta content="{{ opengraph.description|striptags }}" name="description"/>
-    {% endif %}
-    {% if opengraph.profile.username %}
-        <meta content="{{ opengraph.profile.username }}" property="og:profile:username"/>
-    {% endif %}
-    <meta content="{{ opengraph.image.url|default:config.site_icon }}" property="og:image"/>
-    <meta content="{{ opengraph.image.type|default:"image/webp" }}" property="og:image:type"/>
-    {% if opengraph.image.width %}
-        <meta content="{{ opengraph.image.width }}" property="og:image:width" />
-        <meta content="{{ opengraph.image.height }}" property="og:image:height" />
-    {% endif %}
-    {% if opengraph.image.alt %}
-        <meta content="{{ opengraph.image.alt }}" property="og:image:alt" />
-    {% endif %}
+    {% for key, value in opengraph.items %}
+        <meta content="{{ value|striptags }}" property="{{ key }}"/>
+        {% if key == "og:description" %}
+            {# Mastodon duplicates this one tag without the og: prefix. Not sure why #}
+            <meta content="{{ value }}" property="description"/>
+        {% endif %}
+    {% endfor %}
     {% block opengraph_extra %}
-    {% endblock %}
+    {% endblock %}-->
     <!-- End OpenGraph tagging -->
 {% endblock %}
 {% endif %}

--- a/templates/_opengraph.html
+++ b/templates/_opengraph.html
@@ -15,6 +15,7 @@
     {% endif %}
     {% if opengraph.description %}
         <meta content="{{ opengraph.description|striptags }}" property="og:description"/>
+        <meta content="{{ opengraph.description|striptags }}" name="description"/>
     {% endif %}
     {% if opengraph.profile.username %}
         <meta content="{{ opengraph.profile.username }}" property="og:profile:username"/>
@@ -24,6 +25,9 @@
     {% if opengraph.image.width %}
         <meta content="{{ opengraph.image.width }}" property="og:image:width" />
         <meta content="{{ opengraph.image.height }}" property="og:image:height" />
+    {% endif %}
+    {% if opengraph.image.alt %}
+        <meta content="{{ opengraph.image.alt }}" property="og:image:alt" />
     {% endif %}
     {% block opengraph_extra %}
     {% endblock %}

--- a/templates/_opengraph.html
+++ b/templates/_opengraph.html
@@ -1,17 +1,14 @@
-{% if opengraph.disabled %}
-    <!-- OpenGraph tagging disabled on this page -->
-{% else %}
-{% block opengraph %}
+{% load opengraph %}
+{% with opengraph_merged=opengraph_local|dict_merge:opengraph_defaults %}
     <!-- Begin OpenGraph tagging -->
-    {% for key, value in opengraph.items %}
+    {% for key, value in opengraph_merged.items %}
         <meta content="{{ value|striptags }}" property="{{ key }}"/>
         {% if key == "og:description" %}
             {# Mastodon duplicates this one tag without the og: prefix. Not sure why #}
-            <meta content="{{ value }}" property="description"/>
+            <meta content="{{ value|striptags }}" property="description"/>
         {% endif %}
     {% endfor %}
     {% block opengraph_extra %}
-    {% endblock %}-->
+    {% endblock %}
     <!-- End OpenGraph tagging -->
-{% endblock %}
-{% endif %}
+{% endwith %}

--- a/templates/_opengraph.html
+++ b/templates/_opengraph.html
@@ -14,7 +14,7 @@
         <meta content="{{ opengraph.modifed_time }}" property="og:modifed_time"/>
     {% endif %}
     {% if opengraph.description %}
-        <meta content="{{ opengraph.description }}" property="og:description"/>
+        <meta content="{{ opengraph.description|striptags }}" property="og:description"/>
     {% endif %}
     {% if opengraph.profile.username %}
         <meta content="{{ opengraph.profile.username }}" property="og:profile:username"/>

--- a/templates/activities/post.html
+++ b/templates/activities/post.html
@@ -2,6 +2,10 @@
 
 {% block title %}Post by {{ post.author.html_name_or_handle }}{% endblock %}
 
+{% block opengraph %}
+    {% include "_opengraph.html" with opengraph_local=post.to_opengraph_dict %}
+{% endblock %}
+
 {% block content %}
     {% for ancestor in ancestors reversed %}
         {% include "activities/_post.html" with post=ancestor reply=True link_original=False %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,6 +25,7 @@
     {% if config_identity.custom_css %}
       <style>{{ config_identity.custom_css }}</style>
     {% endif %}
+    {% include "_opengraph.html" %}
     {% block extra_head %}{% endblock %}
 </head>
 <body class="{% block body_class %}{% endblock %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,7 +25,9 @@
     {% if config_identity.custom_css %}
       <style>{{ config_identity.custom_css }}</style>
     {% endif %}
-    {% include "_opengraph.html" %}
+    {% block opengraph %}
+        {% include "_opengraph.html" with opengraph_local=opengraph_defaults %}
+    {% endblock %}
     {% block extra_head %}{% endblock %}
 </head>
 <body class="{% block body_class %}{% endblock %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>

--- a/templates/identity/view.html
+++ b/templates/identity/view.html
@@ -2,6 +2,10 @@
 
 {% block title %}{{ identity }}{% endblock %}
 
+{% block opengraph %}
+    {% include "_opengraph.html" with opengraph_local=identity.to_opengraph_dict %}
+{% endblock %}
+
 {% block extra_head %}
     {% if identity.local %}
         <link rel="alternate" type="application/rss+xml" title="RSS feed for {{ identity.name }}" href="rss/" />

--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -735,6 +735,19 @@ class Identity(StatorModel):
                 await sync_to_async(self.save)()
         return True
 
+    ### OpenGraph API ###
+
+    def to_opengraph_dict(self) -> dict:
+        return {
+            "og:title": f"{self.name} (@{self.handle})",
+            "og:type": "profile",
+            "og:description": self.summary,
+            "og:profile:username": self.handle,
+            "og:image:url": self.local_icon_url().absolute,
+            "og:image:height": 85,
+            "og:image:width": 85,
+        }
+
     ### Mastodon Client API ###
 
     def to_mastodon_json(self):

--- a/users/views/identity.py
+++ b/users/views/identity.py
@@ -1,5 +1,6 @@
 import string
 
+import bleach
 from django import forms
 from django.contrib.auth.decorators import login_required
 from django.contrib.syndication.views import Feed
@@ -70,6 +71,19 @@ class ViewIdentity(ListView):
         context["identity"] = self.identity
         context["follow"] = None
         context["reverse_follow"] = None
+        context["opengraph"] = {
+            "type": "profile",
+            "title": f"{self.identity.name} (@{self.identity.handle})",
+            "description": bleach.clean(self.identity.summary or "", strip=True),
+            "profile": {
+                "username": self.identity.handle,
+            },
+            "image": {
+                "url": self.identity.local_icon_url().absolute,
+                "height": 85,
+                "width": 85,
+            },
+        }
         context["interactions"] = PostInteraction.get_post_interactions(
             context["page_obj"],
             self.request.identity,

--- a/users/views/identity.py
+++ b/users/views/identity.py
@@ -70,19 +70,6 @@ class ViewIdentity(ListView):
         context["identity"] = self.identity
         context["follow"] = None
         context["reverse_follow"] = None
-        context["opengraph"] = {
-            "type": "profile",
-            "title": f"{self.identity.name} (@{self.identity.handle})",
-            "description": self.identity.summary,
-            "profile": {
-                "username": self.identity.handle,
-            },
-            "image": {
-                "url": self.identity.local_icon_url().absolute,
-                "height": 85,
-                "width": 85,
-            },
-        }
         context["interactions"] = PostInteraction.get_post_interactions(
             context["page_obj"],
             self.request.identity,

--- a/users/views/identity.py
+++ b/users/views/identity.py
@@ -1,6 +1,5 @@
 import string
 
-import bleach
 from django import forms
 from django.contrib.auth.decorators import login_required
 from django.contrib.syndication.views import Feed
@@ -74,7 +73,7 @@ class ViewIdentity(ListView):
         context["opengraph"] = {
             "type": "profile",
             "title": f"{self.identity.name} (@{self.identity.handle})",
-            "description": bleach.clean(self.identity.summary or "", strip=True),
+            "description": self.identity.summary,
             "profile": {
                 "username": self.identity.handle,
             },


### PR DESCRIPTION
Creates an OpenGraph template include in base.html including the basic tags expected on all pages.

Then allows any page to add additional expected tags via `context`.

Currently, profiles and posts are enriched to show complete opengraph metadata, and render correctly in Discord.

Note: This does not show posts in Slack like Twitter/Mastodon do. I believe this is due to Slack preferring oembed when present, which is a mastodon API endpoint we may need to create at some point.