### PR TITLE
Render the Nginx config to a separate file

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+nginx.rendered.conf

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,10 +2,10 @@
 
 # Set up cache size
 CACHE_SIZE="${TAKAHE_NGINX_CACHE_SIZE:-1g}"
-sed -i s/__CACHESIZE__/${CACHE_SIZE}/g /takahe/docker/nginx.conf
+sed s/__CACHESIZE__/${CACHE_SIZE}/g /takahe/docker/nginx.conf > /takahe/docker/nginx.rendered.conf
 
 # Run nginx and gunicorn
-nginx -c "/takahe/docker/nginx.conf" &
+nginx -c "/takahe/docker/nginx.rendered.conf" &
 
 gunicorn takahe.wsgi:application -b 0.0.0.0:8001 &
 


### PR DESCRIPTION
When writing the cache size to nginx config, write it to a separate file so it doesn't confuse git status/commit.

By using a rendered file, we can ignore the output completely.