### PR TITLE
Move  nginx to separate container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,8 +24,6 @@ x-takahe-common:
       - external_network
       - internal_network
     restart: on-failure
-    depends_on:
-      - db
     volumes:
       - ..:/takahe/
 
@@ -34,6 +32,8 @@ services:
     image: docker.io/postgres:15-alpine
     healthcheck:
       test: ['CMD', 'pg_isready', '-U', 'postgres']
+      interval: 1s
+      retries: 20
     volumes:
       - dbdata:/var/lib/postgresql/data
     networks:
@@ -43,19 +43,39 @@ services:
       POSTGRES_DB: takahe
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: insecure_password
+    ports:
+      - "5433:5432"
+
+  nginx:
+    <<: *takahe-common
+    ports:
+      - "8000:8000"
+    depends_on:
+      web:
+        condition: service_started
 
   web:
     <<: *takahe-common
     ports:
-      - "8000:8000"
+      - "8001:8001"
+    command: ["gunicorn", "takahe.wsgi:application", "-b", "0.0.0.0:8001", "--reload"]
+    depends_on:
+      setup:
+        condition: service_completed_successfully
 
   stator:
     <<: *takahe-common
     command: ["/takahe/manage.py", "runstator"]
+    depends_on:
+      setup:
+        condition: service_completed_successfully
 
   setup:
     <<: *takahe-common
     command: ["/takahe/manage.py", "migrate"]
+    depends_on:
+      db:
+        condition: service_healthy
 
 networks:
   internal_network:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -12,7 +12,7 @@ http {
     proxy_cache_path /cache/nginx levels=1:2 keys_zone=takahe:20m inactive=14d max_size=__CACHESIZE__;
 
     upstream takahe {
-        server "127.0.0.1:8001";
+        server "web:8001";
     }
 
     # access_log /dev/stdout;

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -4,13 +4,4 @@
 CACHE_SIZE="${TAKAHE_NGINX_CACHE_SIZE:-1g}"
 sed -i s/__CACHESIZE__/${CACHE_SIZE}/g /takahe/docker/nginx.conf
 
-# Run nginx and gunicorn
-nginx -c "/takahe/docker/nginx.conf" &
-
-gunicorn takahe.wsgi:application -b 0.0.0.0:8001 &
-
-# Wait for any process to exit
-wait -n
-
-# Exit with status of process that exited first
-exit $?
+exec nginx -c "/takahe/docker/nginx.conf"


### PR DESCRIPTION
By moving nginx to its own container, we make it _vastly_ easier to insert a debugger into the environment. Once gunicorn/django is on its own container, we can inject our debugger there without affecting the nginx process.

This assumes that nginx and gunicorn don't have any shared files on disk, which doesn't appear to be the case today. If such a thing is added, a shared volume will be required.

Specifically, this unlocks trivial PyCharm debugging (and presumably other debuggers)

Additionally:
* Create dependency tree within all containers, and specify healthcheck should complete
* Expose all container service ports for debugging
* Improve healthcheck timing on postgres container