### PR TITLE
Introduce debugger friendly docker-compose-split.yml

### DIFF
--- a/docker/docker-compose-split.yml
+++ b/docker/docker-compose-split.yml
@@ -1,0 +1,55 @@
+version: "3.4"
+
+# This compose file is meant to create a debugging surface for IDEs and should not be used for production
+# To minimize drift, this file should extend the base rather than creating any new services.
+#
+# Note: The `app` service extends from stator rather than web because extend won't let us null out the `ports` in
+# the base file. So we have to extend a service that doesn't expose any ports. A bit of a hack.
+
+services:
+  db:
+    extends:
+      service: db
+      file: docker-compose.yml
+
+  nginx:
+    extends:
+      service: web
+      file: docker-compose.yml
+    environment:
+      DISABLE_GUNICORN_RUN: true
+      NGINX_GUNICORN_HOST: app
+    depends_on:
+      - app
+      - stator
+
+  app:
+    extends:
+      service: stator
+      file: docker-compose.yml
+    environment:
+      DISABLE_NGINX_RUN: true
+    command: ["/takahe/docker/run.sh"]
+    depends_on:
+      - setup
+      - db
+
+  stator:
+    extends:
+      service: stator
+      file: docker-compose.yml
+    depends_on:
+      - setup
+      - db
+
+  setup:
+    extends:
+      service: setup
+      file: docker-compose.yml
+
+networks:
+  internal_network:
+  external_network:
+
+volumes:
+  dbdata:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -12,7 +12,7 @@ http {
     proxy_cache_path /cache/nginx levels=1:2 keys_zone=takahe:20m inactive=14d max_size=__CACHESIZE__;
 
     upstream takahe {
-        server "127.0.0.1:8001";
+        server "__GUNICORN_HOST__:8001";
     }
 
     # access_log /dev/stdout;

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,13 +1,34 @@
 #!/bin/bash
 
-# Set up cache size
-CACHE_SIZE="${TAKAHE_NGINX_CACHE_SIZE:-1g}"
-sed s/__CACHESIZE__/${CACHE_SIZE}/g /takahe/docker/nginx.conf > /takahe/docker/nginx.rendered.conf
+function run_gunicorn() {
+  # Provide hook for disable gunicorn in development
+  [ -n "$DISABLE_GUNICORN_RUN" ] && echo "gunicorn disabled" && return
 
-# Run nginx and gunicorn
-nginx -c "/takahe/docker/nginx.rendered.conf" &
+  gunicorn takahe.wsgi:application -b 0.0.0.0:8001 $GUNICORN_EXTRA_CMD_ARGS &
+}
 
-gunicorn takahe.wsgi:application -b 0.0.0.0:8001 $GUNICORN_EXTRA_CMD_ARGS &
+function run_nginx() {
+  # Provide hook for disabling nginx in development
+  [ -n "$DISABLE_NGINX_RUN" ] && echo "nginx disabled" && return
+
+  # Reset the rendered file before rewriting below
+  cp /takahe/docker/nginx.conf /takahe/docker/nginx.rendered.conf
+
+  # Set up cache size
+  CACHE_SIZE="${TAKAHE_NGINX_CACHE_SIZE:-1g}"
+  sed -i s/__CACHESIZE__/${CACHE_SIZE}/g /takahe/docker/nginx.rendered.conf
+
+  # Set the gunicorn host (used primarily for development override)
+  NGINX_GUNICORN_HOST="${NGINX_GUNICORN_HOST:-127.0.0.1}"
+  sed -i s/__GUNICORN_HOST__/${NGINX_GUNICORN_HOST}/g /takahe/docker/nginx.rendered.conf
+
+  # Run nginx and gunicorn
+  nginx -c "/takahe/docker/nginx.rendered.conf" &
+}
+
+run_nginx
+
+run_gunicorn
 
 # Wait for any process to exit
 wait -n

--- a/docs/ide.md
+++ b/docs/ide.md
@@ -1,0 +1,29 @@
+# IDE Development
+
+IDE development and debugging should be possible, and is currently tested/used in PyCharm by some developers.
+
+Please document additional IDEs below if you are familiar with how to set them up.
+
+## PyCharm
+
+To configure full development/debugging in PyCharm, please run through the checklist below:
+
+1. Create a python interpreter within Docker Compose
+    1. Go to Settings > Project > Python Interpreter
+    2. Add Interpreter > Docker Compose
+        * Server: Docker
+        * Configuration Files: `docker/docker-compose-split.yml`
+        * Service: `app`
+    3. Click next and select the auto-populated system interpreter (`/usr/local/bin/python3`)
+4. At this point PyCharm will use the interpreter inside docker for package resolution and auto-complete
+5. To run/debug Django, create a new run configuration
+    1. Create a new `Django Server` configuration
+    2. Most details are left as the default, except
+        * Port: `8001`
+        * Python Interpreter: Set this to the newly created remote interpreter from above (select the version that isn't the project default)
+        * Docker Compose Command and Options: `up nginx`
+6. All set!
+
+Notes:
+* You can choose to use a local interpreter or your docker compose interpreter for the project default. Either works
+and your django run/debug configuration will use docker compose at all times


### PR DESCRIPTION
To support the new debugger compose definition, tweak run.sh to spawn nginx/gunicorn from function calls with kill switches. We can then call these kill switches as needed during development mode.

This change has no impact on production or default workflows.