### PR TITLE
Disable opengraph block in base_plain.html

### DIFF
--- a/templates/base_plain.html
+++ b/templates/base_plain.html
@@ -2,6 +2,10 @@
 
 {% block body_class %}no-sidebar{% endblock %}
 
+{% block opengraph %}
+    {# Error pages don't have the context loaded, so disable opengraph to keep it from spewing errors #}
+{% endblock %}
+
 {% block body_main %}
     <header>
         <menu>


### PR DESCRIPTION
Since error pages lack the normal context, remove the block so it doesn't obscure errors with spew.