### PR TITLE
Add cache-control header for static assets

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -38,6 +38,9 @@ http {
 
         # Serves static files from the collected dir
         location /static/ {
+            # Files in static have cache-busting hashes in the name, thus can be cached forever
+            add_header Cache-Control "public, max-age=604800, immutable";
+
             alias /takahe/static-collected/;
             try_files $uri /static//static-real$uri;
         }


### PR DESCRIPTION
Easy to do this for the static assets, since they have cache-busting hashes.

I think we may want to move the proxy images to have hash filenames as well, like Mastodon does, so we can set the `immutable` cache setting on them as well. Something for later though.