### PR TITLE
Add ability to customise Django settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /docs/_build
 /media/
 /static-collected
+/takahe/local_settings.py
 __pycache__/
 api-test.*
 fly.toml

--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -64,8 +64,11 @@ class Settings(BaseSettings):
     #: Should django run in debug mode?
     DEBUG: bool = False
 
-    # Should the debug toolbar be loaded?
+    #: Should the debug toolbar be loaded?
     DEBUG_TOOLBAR: bool = False
+
+    #: Should we atttempt to import the 'local_settings.py'
+    LOCAL_SETTINGS: bool = False
 
     #: Set a secret key used for signing values such as sessions. Randomized
     #: by default, so you'll logout everytime the process restarts.
@@ -405,3 +408,7 @@ TAKAHE_USER_AGENT = (
     f"python-httpx/{httpx.__version__} "
     f"(Takahe/{__version__}; +https://{SETUP.MAIN_DOMAIN}/)"
 )
+
+if SETUP.LOCAL_SETTINGS:
+    # Let any errors bubble up
+    from .local_settings import *  # noqa


### PR DESCRIPTION
@andrewgodwin PR is intended as a decision point about how we'd like to encourage people to handle custom settings overrides.

1. People set `DJANGO_SETTINGS_MODULE` and then do whatever they're going to do, optionally importing our settings.py
    * More flexible
    * Harder to troubleshoot and document
2. This PR, we do the normal settings.py before optionally importing a fixed path
    * Less flexible (requires `DJANGO_SETTINGS_MODULE` for any pre-Takahē settings code)
    * Common pattern that can be documented
    * Solves the common case of "add to INSTALLED_APPS" and add extra settings without people potentially not importing settings.py
