### PR TITLE
Use cache-busting URLs for proxied files

### DIFF
--- a/activities/models/emoji.py
+++ b/activities/models/emoji.py
@@ -168,7 +168,9 @@ class Emoji(StatorModel):
             if self.file:
                 return AutoAbsoluteUrl(self.file.url)
             elif self.remote_url:
-                return AutoAbsoluteUrl(f"/proxy/emoji/{self.pk}/")
+                return AutoAbsoluteUrl(
+                    f"/proxy/emoji/{self.pk}/", hash_tail_input=self.remote_url
+                )
         return StaticAbsoluteUrl("img/blank-emoji-128.png")
 
     def as_html(self):

--- a/activities/models/post_attachment.py
+++ b/activities/models/post_attachment.py
@@ -81,13 +81,17 @@ class PostAttachment(StatorModel):
         elif self.file:
             return RelativeAbsoluteUrl(self.file.url)
         else:
-            return AutoAbsoluteUrl(f"/proxy/post_attachment/{self.pk}/")
+            return AutoAbsoluteUrl(
+                f"/proxy/post_attachment/{self.pk}/", hash_tail_input=self.remote_url
+            )
 
     def full_url(self):
         if self.file:
             return RelativeAbsoluteUrl(self.file.url)
         else:
-            return AutoAbsoluteUrl(f"/proxy/post_attachment/{self.pk}/")
+            return AutoAbsoluteUrl(
+                f"/proxy/post_attachment/{self.pk}/", hash_tail_input=self.remote_url
+            )
 
     ### ActivityPub ###
 

--- a/core/uris.py
+++ b/core/uris.py
@@ -1,3 +1,4 @@
+import hashlib
 import sys
 from urllib.parse import urljoin
 
@@ -27,8 +28,19 @@ class AutoAbsoluteUrl(RelativeAbsoluteUrl):
     or a passed identity's URI domain.
     """
 
-    def __init__(self, relative: str, identity=None):
+    def __init__(
+        self,
+        relative: str,
+        identity=None,
+        hash_tail_input: str | None = None,
+        hash_tail_length: int = 10,
+    ):
         self.relative = relative
+        if hash_tail_input:
+            # When provided, attach a hash of the input (typically the proxied URL)
+            # SHA1 chosen as it generally has the best performance in modern python, and security is not a concern
+            # Hash truncation is generally fine, as in the typical use case the hash is scoped to the identity PK
+            self.relative += f"{hashlib.sha1(hash_tail_input.encode('ascii')).hexdigest()[:hash_tail_length]}/"
         if identity:
             absolute_prefix = f"https://{identity.domain.uri_domain}/"
         else:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -104,8 +104,6 @@ http {
             proxy_cache_valid 301 307 12h;
             proxy_cache_valid 500 502 503 504 0s;
             proxy_cache_valid any 72h;
-            proxy_hide_header Cache-Control;
-            add_header Cache-Control "public, max-age=3600";
             add_header X-Cache $upstream_cache_status;
         }
 

--- a/mediaproxy/views.py
+++ b/mediaproxy/views.py
@@ -31,7 +31,7 @@ class BaseProxyView(View):
                 headers={
                     "X-Accel-Redirect": "/__takahe_accel__/",
                     "X-Takahe-RealUri": remote_url,
-                    "Cache-Control": "public, max-age=3600",
+                    "Cache-Control": "public",
                 },
             )
         else:
@@ -52,7 +52,9 @@ class BaseProxyView(View):
                     "Content-Type": remote_response.headers.get(
                         "Content-Type", "application/octet-stream"
                     ),
-                    "Cache-Control": "public, max-age=3600",
+                    "Cache-Control": remote_response.headers.get(
+                        "Cache-Control", "public, max-age=3600"
+                    ),
                 },
             )
 

--- a/takahe/urls.py
+++ b/takahe/urls.py
@@ -211,23 +211,23 @@ urlpatterns = [
     path("debug/500/", debug.ServerError.as_view()),
     path("debug/oauth_authorize/", debug.OauthAuthorize.as_view()),
     # Media/image proxy
-    path(
-        "proxy/identity_icon/<identity_id>/",
+    re_path(
+        "^proxy/identity_icon/(?P<identity_id>[^/]+)/((?P<image_hash>[^/]+)/)?$",
         mediaproxy.IdentityIconCacheView.as_view(),
         name="proxy_identity_icon",
     ),
-    path(
-        "proxy/identity_image/<identity_id>/",
+    re_path(
+        "^proxy/identity_image/(?P<identity_id>[^/]+)/((?P<image_hash>[^/]+)/)?$",
         mediaproxy.IdentityImageCacheView.as_view(),
         name="proxy_identity_image",
     ),
-    path(
-        "proxy/post_attachment/<attachment_id>/",
+    re_path(
+        "^proxy/post_attachment/(?P<attachment_id>[^/]+)/((?P<image_hash>[^/]+)/)?$",
         mediaproxy.PostAttachmentCacheView.as_view(),
         name="proxy_post_attachment",
     ),
-    path(
-        "proxy/emoji/<emoji_id>/",
+    re_path(
+        "^proxy/emoji/(?P<emoji_id>[^/]+)/((?P<image_hash>[^/]+)/)?$",
         mediaproxy.EmojiCacheView.as_view(),
         name="proxy_emoji",
     ),

--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -268,7 +268,9 @@ class Identity(StatorModel):
         if self.icon:
             return RelativeAbsoluteUrl(self.icon.url)
         elif self.icon_uri:
-            return AutoAbsoluteUrl(f"/proxy/identity_icon/{self.pk}/")
+            return AutoAbsoluteUrl(
+                f"/proxy/identity_icon/{self.pk}/", hash_tail_input=self.icon_uri
+            )
         else:
             return StaticAbsoluteUrl("img/unknown-icon-128.png")
 
@@ -279,7 +281,9 @@ class Identity(StatorModel):
         if self.image:
             return AutoAbsoluteUrl(self.image.url)
         elif self.image_uri:
-            return AutoAbsoluteUrl(f"/proxy/identity_image/{self.pk}/")
+            return AutoAbsoluteUrl(
+                f"/proxy/identity_image/{self.pk}/", hash_tail_input=self.image_uri
+            )
         return None
 
     @property


### PR DESCRIPTION
Migrates (in a backwards-compatible way) from `/proxy/identity_image/271/` to `/proxy/identity_image/271/f5d8e72f2b/`.

The "hash tail" is generated as a truncated SHA1 of the upstream URL. This allows us to respect the `Cache-Control` header we get from upstream, as if the image changes for the identity then the hash will also change.

In other words, while the previous arrangement forced Takahē to replace the cache-headers because it didn't know when upstream changed, the new setup will immediately update the URL when the upstream does.

Overall, this gives us two benefits:
* Upstream cache settings are preserved, respecting the server's wishes
* Any upstream change will immediately propagate through all caches, including nginx and any CDNs

Nothing actually parses the hash, it exists only to bust the cache. The security of the hash doesn't matter, and the length doesn't really matter either (because it is scoped to the identity PK).

Any attempts to reach the "old" URL without a hash will continue to work, though the upstream cache-control headers will be used.

Note: If an upstream does have "bad" cache control settings, this will allow it to affect the CDN/client. While not ideal, this seems a reasonable tradeoff (and nginx will maintain its cache independently).

To see this in action, it is deployed to my test server: https://takahe.tabletcorry.com/@mark@tapbots.social/