### PR TITLE
Identity.by_username_and_domain has more awareness of Domain

### DIFF
--- a/activities/services/search.py
+++ b/activities/services/search.py
@@ -44,7 +44,7 @@ class SearchService:
                 if self.identity is not None:
                     # Allow authenticated users to fetch remote
                     identity = Identity.by_username_and_domain(
-                        username, domain, fetch=True
+                        username, domain_instance or domain, fetch=True
                     )
                     if identity and identity.state == IdentityStates.outdated:
                         async_to_sync(identity.fetch_actor)()

--- a/users/shortcuts.py
+++ b/users/shortcuts.py
@@ -25,7 +25,7 @@ def by_handle_or_404(request, handle, local=True, fetch=False) -> Identity:
         domain = domain_instance.domain
     identity = Identity.by_username_and_domain(
         username,
-        domain,
+        domain_instance,
         local=local,
         fetch=fetch,
     )


### PR DESCRIPTION
If you (hard) delete a local identity, certain code paths would result in doing fetches to local domains. This PR prevents this and avoids a redundant `Domain.objects.get()` in most situations.