### PR TITLE
Create Django stubs aware mypy config

### DIFF
--- a/.mypy_django.ini
+++ b/.mypy_django.ini
@@ -1,0 +1,5 @@
+[mypy]
+plugins = mypy_django_plugin.main
+
+[mypy.plugins.django-stubs]
+django_settings_module = "takahe.settings"

--- a/mypy_django.sh
+++ b/mypy_django.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+# Change directory to the project root directory.
+cd "$(dirname "$0")"
+
+# The HEAD version of django-stubs is required due to unreleased fixes
+pip install --quiet --no-input \
+  -r requirements-dev.txt \
+  types-pyopenssl \
+  types-bleach \
+  types-mock \
+  types-cachetools \
+  types-python-dateutil \
+  types-docutils \
+  mypy \
+  git+https://github.com/typeddjango/django-stubs.git@master
+
+export TAKAHE_DATABASE_SERVER="postgres://x@example.com/x"
+python3 manage.py collectstatic --noinput
+
+mypy --config-file .mypy_django.ini --ignore-missing-imports --exclude '^venv/' --exclude '^.venv/' --exclude '^tests/' .


### PR DESCRIPTION
The script is a bit of a hack, so open to suggestions. It does work, though the output is rather noisy. Currently, this is useful for occasional manual review of uncaught typing issues.

May be better to cram this in a folder, but wasn't sure what to name it. Worst case, this may help someone in the future who knows how to get this cleanly into pre-commit.

The main issue for pre-commit is that you need _all_ the packages installed for this version of mypy to work, and pre-commit doesn't have them installed in the environment. In theory pre-commit could call this script, but it will be a bit slow/messy.