### PR TITLE
Correctly handle response.raise_for_status()

### DIFF
--- a/activities/services/search.py
+++ b/activities/services/search.py
@@ -41,15 +41,18 @@ class SearchService:
                     username__iexact=username,
                 )
             except Identity.DoesNotExist:
+                identity = None
                 if self.identity is not None:
-                    # Allow authenticated users to fetch remote
-                    identity = Identity.by_username_and_domain(
-                        username, domain_instance or domain, fetch=True
-                    )
-                    if identity and identity.state == IdentityStates.outdated:
-                        async_to_sync(identity.fetch_actor)()
-                else:
-                    identity = None
+                    try:
+                        # Allow authenticated users to fetch remote
+                        identity = Identity.by_username_and_domain(
+                            username, domain_instance or domain, fetch=True
+                        )
+                        if identity and identity.state == IdentityStates.outdated:
+                            async_to_sync(identity.fetch_actor)()
+                    except ValueError:
+                        pass
+
             if identity:
                 results.add(identity)
 

--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -639,7 +639,7 @@ class Identity(StatorModel):
                     headers={"Accept": "application/json"},
                 )
                 response.raise_for_status()
-            except httpx.RequestError as ex:
+            except httpx.HTTPError as ex:
                 response = getattr(ex, "response", None)
                 if (
                     response


### PR DESCRIPTION
Correctly handle response.raise_for_status() and guard search from bubbling parse errors