### PR TITLE
Attach the first image of post to RSS feed

### DIFF
--- a/users/views/identity.py
+++ b/users/views/identity.py
@@ -6,6 +6,7 @@ from django.contrib.syndication.views import Feed
 from django.core import validators
 from django.http import Http404, JsonResponse
 from django.shortcuts import redirect
+from django.utils import feedgenerator
 from django.utils.decorators import method_decorator
 from django.views.decorators.vary import vary_on_headers
 from django.views.generic import FormView, ListView, TemplateView, View
@@ -127,6 +128,18 @@ class IdentityFeed(Feed):
 
     def item_pubdate(self, item: Post):
         return item.published
+
+    def item_enclosures(self, item: Post):
+        attachment = item.attachments.first()
+        if attachment is None:
+            return []
+
+        enc = feedgenerator.Enclosure(
+            url=attachment.full_url().absolute,
+            length=str(attachment.file.size),
+            mime_type=attachment.mimetype,
+        )
+        return [enc]
 
 
 class IdentityFollows(ListView):


### PR DESCRIPTION
Hi, this resolves #104 to allow RSS viewers to show the first image of each post.

## Example RSS feed

```diff
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
  <channel>
    <title>TAKAHASHI Shuuji 🌈✨</title>
    <link>https://takahe-dev.shuuji3.xyz/@shuuji3/</link>
    <link href="http://cf99ec28.takahe-dev.shuuji3.xyz/@shuuji3@takahe-dev.shuuji3.xyz/rss/" rel="self"></link>
    <description>Public posts from @shuuji3@takahe-dev.shuuji3.xyz</description>
    <language>en-us</language>
    <lastBuildDate>Sat, 31 Dec 2022 10:59:24 +0000</lastBuildDate>
    <item>
      <title>shuuji3@takahe-dev.shuuji3.xyz #2</title>
      <link>https://takahe-dev.shuuji3.xyz/@shuuji3/posts/2/</link>
      <description>&lt;p&gt;Post with 4 images! 🖼&lt;/p&gt;</description>
      <pubDate>Sat, 31 Dec 2022 10:59:24 +0000</pubDate>
      <guid>https://takahe-dev.shuuji3.xyz/@shuuji3/posts/2/</guid>
+     <enclosure length="317410" type="image/webp" url="https://cf99ec28.takahe-dev.shuuji3.xyz/media/attachments/2022/12/31/wNN8V0zk42NYzRMCQmo5r6sySXo.webp"></enclosure>
    </item>
    <item>
      <title>shuuji3@takahe-dev.shuuji3.xyz #1</title>
      <link>https://takahe-dev.shuuji3.xyz/@shuuji3/posts/1/</link>
      <description>&lt;p&gt;Hello, Takahē! 🦚 🌌&lt;/p&gt;</description>
      <pubDate>Sat, 31 Dec 2022 10:56:57 +0000</pubDate>
      <guid>https://takahe-dev.shuuji3.xyz/@shuuji3/posts/1/</guid>
    </item>
  </channel>
</rss>
```
- RSS view: https://cf99ec28.takahe-dev.shuuji3.xyz/%40shuuji3%40takahe-dev.shuuji3.xyz/rss/
- Post view: https://cf99ec28.takahe-dev.shuuji3.xyz/%40shuuji3%40takahe-dev.shuuji3.xyz/

## Preview on Feedly
<img width="941" alt="Screenshot 2022-12-31 at 23 41 51" src="https://user-images.githubusercontent.com/1425259/210141485-4c07291f-86c1-4268-b18b-5b53d8d38aa7.png">

## Multiple images

As mentioned in #104, images in RSS are a bit strange, and the default Django Feed class only permits one image to attach as `<enclosure>` (if returned multiple Enclosure [here](https://github.com/jointakahe/takahe/compare/main...shuuji3:feed-add-image?expand=1#diff-4118e569e6ae19c5af078b2a607944006da015701cb16d068fa5debfe8c2eb5bR142), Django raises Exception). This seems because of historical RSS software limitations (ref. [item contains more than one enclosure](https://validator.w3.org/feed/docs/warning/DuplicateEnclosure.html)).

I think there are two other options. The first one is to use the Media RSS extension: https://www.rssboard.org/media-rss. To implement it in Django, it looks like we need to extend the RSS class. This is also used by Mastodon. Example: https://mastodon.social/@pixelfed.rss. However, I couldn't show multiple images on Feedly.

Another option might be to use embedded HTML in `<description>`. I sometimes see this option in a blog post article and it can contain many images reliably.

I'm going to explore both options to include multiple images later.
