### PR TITLE
Make accessibility text color visible

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1736,7 +1736,7 @@ form .post {
 }
 
 .screenreader-text:focus {
-    color: black;
+    color: var(--color-text-main);
     display: inline-block;
     height: auto;
     width: auto;


### PR DESCRIPTION
This is a small tweak to change the navigation text color to white. These links are useful for keyboard users too. I believe making visible doesn't affect usual users as these are only shown when fucusing.

<img width="420" alt="Screenshot 2023-01-01 at 1 38 20" src="https://user-images.githubusercontent.com/1425259/210151732-4814e240-0bb2-4627-a29d-57ef0f6be63f.png">
<img width="413" alt="Screenshot 2023-01-01 at 1 38 09" src="https://user-images.githubusercontent.com/1425259/210151735-6a8d88c4-4818-4306-b9e4-29973cb2c3c1.png">

Here are the similar real world examples:
- [ARIA: navigation role - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role)
- [Guidance on Web Accessibility and the ADA | ADA.gov](https://www.ada.gov/resources/web-guidance/)