### PR TITLE
fix follow in relationship json

### DIFF
--- a/users/services/identity.py
+++ b/users/services/identity.py
@@ -73,7 +73,7 @@ class IdentityService:
                 target=from_identity,
                 state__in=FollowStates.group_active(),
             ).exists(),
-            "showing_reblogs": follow.boosts,
+            "showing_reblogs": follow and follow.boosts or False,
             "notifying": False,
             "blocking": False,
             "blocked_by": False,
@@ -82,7 +82,7 @@ class IdentityService:
             "requested": False,
             "domain_blocking": False,
             "endorsed": False,
-            "note": follow.note or "",
+            "note": (follow and follow.note) or "",
         }
 
     def set_summary(self, summary: str):


### PR DESCRIPTION
When I added showing/hiding boosts I accidentally broke the identity json response for the cases where there is no follow relationship. This fixes that.