### PR TITLE
Fix incorrect character counting

### DIFF
--- a/activities/views/compose.py
+++ b/activities/views/compose.py
@@ -29,7 +29,6 @@ class Compose(FormView):
             widget=forms.Textarea(
                 attrs={
                     "autofocus": "autofocus",
-                    "maxlength": Config.lazy_system_value("post_length"),
                     "placeholder": "What's on your mind?",
                 },
             )
@@ -62,7 +61,8 @@ class Compose(FormView):
                 "_"
             ] = f"""
                 on load or input
-                set characters to my.value.trim().length
+                -- Unicode-aware counting to match Python
+                set characters to Array.from(my.value.trim()).length
                 put {Config.system.post_length} - characters into #character-counter
 
                 if characters > {Config.system.post_length} then


### PR DESCRIPTION
The previous character counting was returning an incorrect number for some characters such as emojis. For example, `👨‍👨‍👧‍👧` (consisting of `👨\u200d👨\u200d👧\u200d👧`) counts as `7` in Python but the previous code was returning `11`. This is because Python handles characters in Unicode-aware way, but each character in JavaScript is treated as UTF-16 code (2 bytes) and `.length` returns the number of that codepoints.

I had to remove `maxlength` parameter too. This also counts emojis incorrectly and there is no way to change the behavior. There is a discussion about this at WHATWG: [textarea[maxlength] interoperability issue · Issue #1467 · whatwg/html](https://github.com/whatwg/html/issues/1467).

We can safely remove `maxlength` attribute since we now have a hyperscript to prevent clicking "Post" button when too many characters. The `maxlength` had prevented us to paste large text and reduce the characters too.

I noticed `--color-text-error` (used when the counter becomes a negative number) was removed by this commit:
https://github.com/shuuji3/takahe/commit/39013e0b#diff-a5ea33c888430601a659bcbef2da1944097953737f2606282efc13ca6e5fbabaL96
Is this intentional?