### PR TITLE
Don’t run ‘publish dev image’ job in forks

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
+    if: github.repository_owner == 'jointakahe'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo


### PR DESCRIPTION
My fork (and, I assume, most forks) doesn’t have the secrets defined, so this job just fails every night. So it’ll be less noisy and less wasteful of resources to disable this job for forks.