### PR TITLE
Fix absolute url error while uploading media with local media backend

### DIFF
--- a/activities/models/post_attachment.py
+++ b/activities/models/post_attachment.py
@@ -3,7 +3,7 @@ from functools import partial
 from django.db import models
 
 from core.uploads import upload_namer
-from core.uris import ProxyAbsoluteUrl, RelativeAbsoluteUrl
+from core.uris import AutoAbsoluteUrl, ProxyAbsoluteUrl, RelativeAbsoluteUrl
 from stator.models import State, StateField, StateGraph, StatorModel
 
 
@@ -77,18 +77,18 @@ class PostAttachment(StatorModel):
 
     def thumbnail_url(self) -> RelativeAbsoluteUrl:
         if self.thumbnail:
-            return RelativeAbsoluteUrl(self.thumbnail.url)
+            return AutoAbsoluteUrl(self.thumbnail.url)
         elif self.file:
-            return RelativeAbsoluteUrl(self.file.url)
+            return AutoAbsoluteUrl(self.file.url)
         else:
             return ProxyAbsoluteUrl(
                 f"/proxy/post_attachment/{self.pk}/",
                 remote_url=self.remote_url,
             )
 
-    def full_url(self):
+    def full_url(self) -> RelativeAbsoluteUrl:
         if self.file:
-            return RelativeAbsoluteUrl(self.file.url)
+            return AutoAbsoluteUrl(self.file.url)
         else:
             return ProxyAbsoluteUrl(
                 f"/proxy/post_attachment/{self.pk}/",

--- a/core/uris.py
+++ b/core/uris.py
@@ -30,15 +30,18 @@ class AutoAbsoluteUrl(RelativeAbsoluteUrl):
 
     def __init__(
         self,
-        relative: str,
+        url: str,
         identity=None,
     ):
-        self.relative = relative
-        if identity:
-            absolute_prefix = f"https://{identity.domain.uri_domain}/"
+        if "://" in url:
+            super().__init__(url)
         else:
-            absolute_prefix = f"https://{settings.MAIN_DOMAIN}/"
-        self.absolute = urljoin(absolute_prefix, self.relative)
+            self.relative = url
+            if identity:
+                absolute_prefix = f"https://{identity.domain.uri_domain}/"
+            else:
+                absolute_prefix = f"https://{settings.MAIN_DOMAIN}/"
+            self.absolute = urljoin(absolute_prefix, self.relative)
 
 
 class ProxyAbsoluteUrl(AutoAbsoluteUrl):

--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -272,7 +272,7 @@ class Identity(StatorModel):
         Returns an icon for use by us, with fallbacks to a placeholder
         """
         if self.icon:
-            return RelativeAbsoluteUrl(self.icon.url)
+            return AutoAbsoluteUrl(self.icon.url)
         elif self.icon_uri:
             return ProxyAbsoluteUrl(
                 f"/proxy/identity_icon/{self.pk}/",


### PR DESCRIPTION
When using local media backend, the image doesn't have the fqdn part of the URL, so I adapted the `AutoAbsoluteUrl` to be able to deal with both CDN based media and local media automatically.

Fixes: #343 