### PR TITLE
Include an /etc/mime.types file to correct gaps from mimetypes package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,6 +35,8 @@ RUN apt-get update \
 
 RUN mkdir -p /cache
 
+# Python mimetypes package is missing some common mappings
+COPY docker/mime.types /etc/mime.types
 COPY . /takahe
 
 WORKDIR /takahe

--- a/docker/mime.types
+++ b/docker/mime.types
@@ -1,0 +1,1 @@
+image/webp  webp


### PR DESCRIPTION
Make it so `mimetypes.guess_type("somefile.webp")` returns `image/webp`