### PR TITLE
Add custom_head config to inject HTML in to page <head>

### DIFF
--- a/core/models/config.py
+++ b/core/models/config.py
@@ -235,6 +235,8 @@ class Config(models.Model):
 
         restricted_usernames: str = "admin\nadmins\nadministrator\nadministrators\nsystem\nroot\nannounce\nannouncement\nannouncements"
 
+        custom_head: str | None
+
     class UserOptions(pydantic.BaseModel):
 
         pass

--- a/templates/base.html
+++ b/templates/base.html
@@ -30,6 +30,7 @@
         {% include "_opengraph.html" with opengraph_local=opengraph_defaults %}
     {% endblock %}
     {% block extra_head %}{% endblock %}
+    {% block custom_head %}{% if config.custom_head %}{{ config.custom_head|safe }}{% endif %}{% endblock %}
 </head>
 <body class="{% block body_class %}{% endblock %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
     <a id='skip-to-main' class='screenreader-text' href='#main-content'>Skip to Content</a>

--- a/users/views/admin/settings.py
+++ b/users/views/admin/settings.py
@@ -101,6 +101,11 @@ class BasicSettings(AdminSettingsPage):
             "title": "Show Public Timeline On Front Page",
             "help_text": "Whether to show some recent posts on the logged-out homepage",
         },
+        "custom_head": {
+            "title": "HTML <head> Extra",
+            "help_text": "Add custom HTML to the &lt;head&gt; of all pages (except /djadmin/).\nNote: This can break page rendering/layout.",
+            "display": "textarea",
+        },
     }
 
     layout = {
@@ -110,6 +115,7 @@ class BasicSettings(AdminSettingsPage):
             "site_icon",
             "site_banner",
             "highlight_color",
+            "custom_head",
         ],
         "Signups": [
             "signup_allowed",


### PR DESCRIPTION
Needed for adding plausible or other analytics scripts.