### PR TITLE
Re-use page for interaction query

### DIFF
--- a/activities/views/timelines.py
+++ b/activities/views/timelines.py
@@ -25,14 +25,15 @@ class Home(TemplateView):
         events = TimelineService(self.request.identity).home()
         paginator = Paginator(events, 25)
         page_number = self.request.GET.get("page")
+        event_page = paginator.get_page(page_number)
         context = {
             "interactions": PostInteraction.get_event_interactions(
-                events,
+                event_page,
                 self.request.identity,
             ),
             "current_page": "home",
             "allows_refresh": True,
-            "page_obj": paginator.get_page(page_number),
+            "page_obj": event_page,
             "form": self.form_class(request=self.request),
         }
         return context


### PR DESCRIPTION
Original code caused the query on timeline to issue twice. Once to satisfy the interactions lookup (which had no LIMIT) and then again for the page (which had a LIMIT 25). Presumably we want interactions for the paginated events, especially since the un-LIMITed query would become extremely inefficient.

With this fix, the query to get the timeline runs only once, with an appropriate LIMIT (and therefore the query to interactions is much smaller as well).