### PR TITLE
Enable HTTPX integration in Sentry

### DIFF
--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -335,10 +335,13 @@ if SETUP.USE_PROXY_HEADERS:
 
 
 if SETUP.SENTRY_DSN:
+    from sentry_sdk.integrations.httpx import HttpxIntegration
+
     sentry_sdk.init(
         dsn=SETUP.SENTRY_DSN,
         integrations=[
             DjangoIntegration(),
+            HttpxIntegration(),
         ],
         traces_sample_rate=SETUP.SENTRY_TRACES_SAMPLE_RATE,
         sample_rate=SETUP.SENTRY_SAMPLE_RATE,


### PR DESCRIPTION
I don't know a whole lot about HTTPX, but it seems Sentry has an integration for it. Should it be enabled?