### PR TITLE
Update ignore files for broader fly file usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,7 @@
 .mypy_cache
 .pre-commit-config.yaml
 .venv
-fly.toml
+/fly.*
 media
 notes.md
 venv

--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,11 @@
 /build
 /cache/
 /docs/_build
+/fly.*
 /media/
 /static-collected
 /takahe/local_settings.py
 __pycache__/
 api-test.*
-fly.toml
 notes.md
 notes.py


### PR DESCRIPTION
Expand the ignorefiles understanding of fly config files, so Fly users can be a bit more free to do work locally that won't get checked in.