### PR TITLE
Ignore 406 response for webfinger and nodeinfo

### DIFF
--- a/users/models/domain.py
+++ b/users/models/domain.py
@@ -166,7 +166,7 @@ class Domain(StatorModel):
                 if (
                     response
                     and response.status_code < 500
-                    and response.status_code not in [401, 403, 404, 410]
+                    and response.status_code not in [401, 403, 404, 406, 410]
                 ):
                     raise ValueError(
                         f"Client error fetching nodeinfo: domain={self.domain_id}, code={response.status_code}",

--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -658,7 +658,7 @@ class Identity(StatorModel):
                 if (
                     response
                     and response.status_code < 500
-                    and response.status_code not in [401, 403, 404, 410]
+                    and response.status_code not in [401, 403, 404, 406, 410]
                 ):
                     raise ValueError(
                         f"Client error fetching webfinger: {response.status_code}",


### PR DESCRIPTION
Some servers don't accept `application/json` and properly respond with 406.