### PR TITLE
Add Makefile targets for some common/useful development tasks:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,15 +25,10 @@ compose_down:
 	python3 -m pre_commit install
 
 .env:
-	# afterwords, set in .env
-	# TAKAHE_DATABASE_SERVER="postgres://postgres:insecure_password@localhost:5433/takahe"
 	cp development.env .env
 
-_PHONY: pydev
-pydev: .venv
-
-_PHONY: precommit
-precommit: pydev .git/hooks/pre-commit
+_PHONY: setup_local
+setup_local: .venv .env .git/hooks/pre-commit
 
 _PHONY: startdb stopdb
 startdb:
@@ -43,23 +38,20 @@ stopdb:
 	docker compose -f docker/docker-compose.yml stop db
 
 _PHONY: superuser
-createsuperuser: .env pydev startdb
+createsuperuser: setup_local startdb
 	python3 -m manage createsuperuser
 
-_PHONY: pydev
-pydev: pydev precommit
-
 _PHONY: test
-test: pydev
+test: setup_local
 	python3 -m pytest
 
 # Active development
 _PHONY: migrations server stator
-migrations: startdb
+migrations: setup_local startdb
 	python3 -m manage migrate
 
-runserver: startdb
+runserver: setup_local startdb
 	python3 -m manage runserver
 
-runstator: startdb
+runstator: setup_local startdb
 	python3 -m manage runstator

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ stopdb:
 	docker compose -f docker/docker-compose.yml stop db
 
 _PHONY: superuser
-superuser: .env pydev startdb
+createsuperuser: .env pydev startdb
 	python3 -m manage createsuperuser
 
 _PHONY: pydev
@@ -58,8 +58,8 @@ _PHONY: migrations server stator
 migrations: startdb
 	python3 -m manage migrate
 
-server: startdb
+runserver: startdb
 	python3 -m manage runserver
 
-stator: startdb
+runstator: startdb
 	python3 -m manage runstator

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,11 @@ compose_down:
 	# TAKAHE_DATABASE_SERVER="postgres://postgres:insecure_password@localhost:5433/takahe"
 	cp development.env .env
 
-_PHONY: python-dev
-python-dev: .venv
+_PHONY: pydev
+pydev: .venv
 
 _PHONY: precommit
-precommit: python-dev .git/hooks/pre-commit
+precommit: pydev .git/hooks/pre-commit
 
 _PHONY: startdb stopdb
 startdb:
@@ -43,11 +43,11 @@ stopdb:
 	docker compose -f docker/docker-compose.yml stop db
 
 _PHONY: superuser
-superuser: .env python-dev startdb
+superuser: .env pydev startdb
 	python3 -m manage createsuperuser
 
 _PHONY: pydev
-pydev: python-dev precommit
+pydev: pydev precommit
 
 _PHONY: test
 test: pydev

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,52 @@ compose_up:
 
 compose_down:
 	docker-compose -f docker/docker-compose.yml down
+
+# Development Setup
+.venv:
+	python3 -m venv .venv
+	. .venv/bin/activate
+	python3 -m pip install -r requirements-dev.txt
+
+.git/hooks/pre-commit: .venv
+	python3 -m pre_commit install
+
+.env:
+	# afterwords, set in .env
+	# TAKAHE_DATABASE_SERVER="postgres://postgres:insecure_password@localhost:5433/takahe"
+	cp development.env .env
+
+_PHONY: python-dev
+python-dev: .venv
+
+_PHONY: precommit
+precommit: python-dev .git/hooks/pre-commit
+
+_PHONY: startdb stopdb
+startdb:
+	docker compose -f docker/docker-compose.yml up db -d
+
+stopdb:
+	docker compose -f docker/docker-compose.yml stop db
+
+_PHONY: superuser
+superuser: .env python-dev startdb
+	python3 -m manage createsuperuser
+
+_PHONY: pydev
+pydev: python-dev precommit
+
+_PHONY: test
+test: pydev
+	python3 -m pytest
+
+# Active development
+_PHONY: migrations server stator
+migrations: startdb
+	python3 -m manage migrate
+
+server: startdb
+	python3 -m manage runserver
+
+stator: startdb
+	python3 -m manage runstator

--- a/development.env
+++ b/development.env
@@ -1,4 +1,8 @@
-TAKAHE_DATABASE_SERVER="postgres://postgres@localhost/takahe"
+# docker-hosted postgres
+TAKAHE_DATABASE_SERVER="postgres://postgres:insecure_password@localhost:5433/takahe"
+# If you are using a locally-hosted postgres you can comment the above
+# and uncomment the following line
+# TAKAHE_DATABASE_SERVER="postgres://postgres@localhost/takahe"
 TAKAHE_DEBUG=true
 TAKAHE_SECRET_KEY="insecure_secret"
 TAKAHE_CSRF_TRUSTED_ORIGINS=["http://127.0.0.1:8000", "https://127.0.0.1:8000"]


### PR DESCRIPTION
## Development Make Targets

This adds several new `Makefile` targets to help streamline local development.

One decision I made on this was to use the docker-compose postgres rather than assuming a locally-hosted Postgres. Might not be everyone's choice.

### dev setup tasks:

- `.venv`
- /git/hooks/pre-commit
- .env

### db tasks: reuses the docker db container rather than hosting postgres locally:

- startdb
- stopdb
- migrations

### active development tasks:

- server
- stator

## Usage/Example

```
$ make pydev
python3 -m venv .venv
. .venv/bin/activate
python3 -m pip install -r requirements-dev.txt
[snip install stuff...]
Successfully installed Jinja2-3.1.2 MarkupSafe-2.1.1 Pygments...
[snip install stuff...]
python3 -m pre_commit install
pre-commit installed at .git/hooks/pre-commit
```

```
make server
docker compose -f docker/docker-compose.yml up db -d
[+] Running 1/0
 ⠿ Container docker-db-1  Running                                                                                                        0.0s
python3 -m manage runserver
Watching for file changes with StatReloader
Performing system checks...

System check identified no issues (0 silenced).
January 05, 2023 - 16:33:20
Django version 4.1.5, using settings 'takahe.settings'
Starting development server at http://127.0.0.1:8000
```

Closes #357 