### PR TITLE
Update emoji for domain when shortcode doesn't match uri

### DIFF
--- a/api/views/accounts.py
+++ b/api/views/accounts.py
@@ -134,7 +134,7 @@ def account_statuses(
         identity.posts.not_hidden()
         .unlisted(include_replies=not exclude_replies)
         .select_related("author")
-        .prefetch_related("attachments")
+        .prefetch_related("attachments", "mentions__domain", "emojis")
         .order_by("-created")
     )
     if pinned:


### PR DESCRIPTION
This handles the situation where the remote replaces an emoji shortcode with a new record/object_url.