### PR TITLE
Adjust icon position on the right sidebar

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1636,6 +1636,11 @@ form .post {
         font-size: 22px;
     }
 
+    .right-column nav a .fa-solid {
+        display: flex;
+        justify-content: center;
+    }
+
     .right-column h3 {
         visibility: hidden;
     }


### PR DESCRIPTION
Right icons were not centered slightly on the small screen. This is because each icon has a bit different width and they were aligned on the left side. (There is no issue with the large screen.)

<img width="674" alt="takahe-adjust-icon-position" src="https://user-images.githubusercontent.com/1425259/211152377-ba6407c4-d5d3-45cc-b521-79cd6a0dbbd1.png">
