### PR TITLE
Fix left column height on small screen

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1549,11 +1549,6 @@ form .post {
 
 @media (max-width: 920px),
 (display-mode: standalone) {
-    div.columns {
-        height: calc(100vh - 50px);
-        align-items: stretch;
-    }
-
     .left-column {
         margin: var(--md-header-height) var(--md-sidebar-width) 0 0;
     }


### PR DESCRIPTION

This change fixes where there is no margin at the bottom of the left columns. The cause was the current CSS set a small height for the left column when the content is more than one viewport.

<img alt="takahe social_@takahe@jointakahe org.png_" src="https://user-images.githubusercontent.com/1425259/211158103-fc07a4e4-73ff-49c5-a2cf-fd14e11da69e.png" width="400">

**(before -> after)**
<img alt="takahe social_compose_(iPhone SE)" src="https://user-images.githubusercontent.com/1425259/211158279-c9544744-0629-49cb-843e-89b8152bbe49.png" width="300"> <img alt="localhost_8000_compose_(iPhone SE)" src="https://user-images.githubusercontent.com/1425259/211158282-a43d828f-e494-496d-b099-aca7d4a292bb.png" width="300">
