### PR TITLE
Modify emoji loader for cache-optimized return value

### DIFF
--- a/activities/models/emoji.py
+++ b/activities/models/emoji.py
@@ -146,15 +146,18 @@ class Emoji(StatorModel):
 
     @classmethod
     @cached(cache=TTLCache(maxsize=1000, ttl=60))
-    def get_by_domain(cls, shortcode, domain: Domain | None) -> "Emoji":
+    def get_by_domain(cls, shortcode, domain: Domain | None) -> "Emoji | None":
         """
         Given an emoji shortcode and optional domain, looks up the single
         emoji and returns it. Raises Emoji.DoesNotExist if there isn't one.
         """
-        if domain is None or domain.local:
-            return cls.objects.get(local=True, shortcode=shortcode)
-        else:
-            return cls.objects.get(domain=domain, shortcode=shortcode)
+        try:
+            if domain is None or domain.local:
+                return cls.objects.get(local=True, shortcode=shortcode)
+            else:
+                return cls.objects.get(domain=domain, shortcode=shortcode)
+        except Emoji.DoesNotExist:
+            return None
 
     @property
     def fullcode(self):

--- a/core/html.py
+++ b/core/html.py
@@ -214,16 +214,15 @@ class ContentRenderer:
             shortcode = match.group(1).lower()
             if shortcode in cached_emojis:
                 return cached_emojis[shortcode].as_html()
-            try:
-                emoji = Emoji.get_by_domain(shortcode, identity.domain)
-                if emoji.is_usable:
+
+            emoji = Emoji.get_by_domain(shortcode, identity.domain)
+            if emoji and emoji.is_usable:
+                return emoji.as_html()
+            elif not emoji and include_local:
+                emoji = Emoji.get_by_domain(shortcode, None)
+                if emoji:
                     return emoji.as_html()
-            except Emoji.DoesNotExist:
-                if include_local:
-                    try:
-                        return Emoji.get_by_domain(shortcode, identity.domain).as_html()
-                    except Emoji.DoesNotExist:
-                        pass
+
             return match.group()
 
         return Emoji.emoji_regex.sub(replacer, html)


### PR DESCRIPTION
Result: On homepage load drops queries from ~72 to ~14 (and DB time from ~90ms to ~50ms).

Fixes issue where caching decorator takes no action when an exception is returned. As such the "return exception rather than None" pattern is risky where caching is in use.

Notes:
(a) Also fixes an apparent bug in `imageify_emojis.replacer` where `include_local` was not being used correctly (previous code path never returned anything. My modifications may be correct, though it is something of a guess.