### PR TITLE
Move initial cursor place to the end for @mention reply

### DIFF
--- a/activities/views/compose.py
+++ b/activities/views/compose.py
@@ -60,6 +60,11 @@ class Compose(FormView):
             self.fields["text"].widget.attrs[
                 "_"
             ] = f"""
+                init
+                    -- Move cursor to the end of existing text
+                    set my.selectionStart to my.value.length
+                end
+
                 on load or input
                 -- Unicode-aware counting to match Python
                 set characters to Array.from(my.value.trim()).length


### PR DESCRIPTION
This moves the default cursor position to the end of the text. This can avoid the manual cursor move every time to reply.

**Before**
<img width="662" alt="Screenshot 2023-01-01 at 8 21 48" src="https://user-images.githubusercontent.com/1425259/211210712-f5797dd3-8dd4-4436-be2b-328b6f8c3711.png">

**After**
<img width="483" alt="Screenshot 2023-01-09 at 2 40 46" src="https://user-images.githubusercontent.com/1425259/211210771-7aa8e4aa-0e85-4b84-8b6d-fe541fc519c7.png">
