### PR TITLE
Fix image height overflow in the post with single image

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1369,7 +1369,6 @@ form .post {
     object-fit: cover;
     object-position: center;
     max-height: 400px;
-    height: 100%;
     width: 100%;
 }
 


### PR DESCRIPTION
Fixing image height overflow. The HTML structure is like this:

```html
<div class="attachments">
    <a href="...">
        <img src="...">
    </a>
</div>
```

This was because the original `img { height: 100% }` uses the height of `<a>` and it was more than `div.attachments`'s height.

Example posts on takahe.social: https://takahe.social/@shuuji3@takahe.social/

**Before**
<img width="681" alt="Screenshot 2023-01-09 at 14 53 33" src="https://user-images.githubusercontent.com/1425259/211248012-299a3930-3fc7-40a6-9a8d-542e8e6397db.png">

**After**
<img width="674" alt="Screenshot 2023-01-09 at 14 53 44" src="https://user-images.githubusercontent.com/1425259/211248031-9ee69019-a243-4039-8356-0c0d496b0e95.png">
