### PR TITLE
Improve performance on /api/v1/timelines/home

### DIFF
--- a/api/views/timelines.py
+++ b/api/views/timelines.py
@@ -21,6 +21,30 @@ def home(
     # Grab a paginated result set of instances
     paginator = MastodonPaginator()
     queryset = TimelineService(request.identity).home()
+    queryset = queryset.select_related(
+        "subject_post_interaction__post",
+        "subject_post_interaction__post__author",
+        "subject_post_interaction__post__author__domain",
+    )
+    queryset = queryset.prefetch_related(
+        "subject_post__mentions__domain",
+        "subject_post__author__inbound_follows",
+        "subject_post__author__outbound_follows",
+        "subject_post__author__posts",
+        "subject_post__author__inbound_follows",
+        "subject_post__author__outbound_follows",
+        "subject_post__author__posts",
+        "subject_post_interaction__post__attachments",
+        "subject_post_interaction__post__mentions",
+        "subject_post_interaction__post__emojis",
+        "subject_post_interaction__post__mentions__domain",
+        "subject_post_interaction__post__author__inbound_follows",
+        "subject_post_interaction__post__author__outbound_follows",
+        "subject_post_interaction__post__author__posts",
+        "subject_post_interaction__post__author__inbound_follows",
+        "subject_post_interaction__post__author__outbound_follows",
+        "subject_post_interaction__post__author__posts",
+    )
     pager = paginator.paginate_home(
         queryset,
         min_id=min_id,

--- a/api/views/timelines.py
+++ b/api/views/timelines.py
@@ -28,21 +28,13 @@ def home(
     )
     queryset = queryset.prefetch_related(
         "subject_post__mentions__domain",
-        "subject_post__author__inbound_follows",
-        "subject_post__author__outbound_follows",
         "subject_post__author__posts",
-        "subject_post__author__inbound_follows",
-        "subject_post__author__outbound_follows",
         "subject_post__author__posts",
         "subject_post_interaction__post__attachments",
         "subject_post_interaction__post__mentions",
         "subject_post_interaction__post__emojis",
         "subject_post_interaction__post__mentions__domain",
-        "subject_post_interaction__post__author__inbound_follows",
-        "subject_post_interaction__post__author__outbound_follows",
         "subject_post_interaction__post__author__posts",
-        "subject_post_interaction__post__author__inbound_follows",
-        "subject_post_interaction__post__author__outbound_follows",
         "subject_post_interaction__post__author__posts",
     )
     pager = paginator.paginate_home(

--- a/api/views/timelines.py
+++ b/api/views/timelines.py
@@ -28,13 +28,10 @@ def home(
     )
     queryset = queryset.prefetch_related(
         "subject_post__mentions__domain",
-        "subject_post__author__posts",
-        "subject_post__author__posts",
         "subject_post_interaction__post__attachments",
         "subject_post_interaction__post__mentions",
         "subject_post_interaction__post__emojis",
         "subject_post_interaction__post__mentions__domain",
-        "subject_post_interaction__post__author__posts",
         "subject_post_interaction__post__author__posts",
     )
     pager = paginator.paginate_home(


### PR DESCRIPTION
Prefetch/select required fields for API version of home. Requires considerably more data than HTML version of home.

Results:
* Before 699.486 [ms] (>100+ SQL queries)
* After 376.082 [ms] (~16 SQL queries)