### PR TITLE
Silence a few common errors when fetching

### DIFF
--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -1,3 +1,4 @@
+import ssl
 from functools import cached_property, partial
 from typing import Literal
 from urllib.parse import urlparse
@@ -642,7 +643,10 @@ class Identity(StatorModel):
         (actor uri, canonical handle) or None, None if it does not resolve.
         """
         domain = handle.split("@")[1].lower()
-        webfinger_url = await cls.fetch_webfinger_url(domain)
+        try:
+            webfinger_url = await cls.fetch_webfinger_url(domain)
+        except ssl.SSLCertVerificationError:
+            return None, None
 
         # Go make a Webfinger request
         async with httpx.AsyncClient(
@@ -656,7 +660,7 @@ class Identity(StatorModel):
                     headers={"Accept": "application/json"},
                 )
                 response.raise_for_status()
-            except httpx.RequestError as ex:
+            except (httpx.HTTPError, ssl.SSLCertVerificationError) as ex:
                 response = getattr(ex, "response", None)
                 if (
                     response
@@ -703,25 +707,24 @@ class Identity(StatorModel):
                 method="get",
                 uri=self.actor_uri,
             )
-        except httpx.RequestError:
+        except (httpx.RequestError, ssl.SSLCertVerificationError):
             return False
         content_type = response.headers.get("content-type")
         if content_type and "html" in content_type:
             # Some servers don't properly handle "application/activity+json"
             return False
-        if response.status_code == 410:
-            # Their account got deleted, so let's do the same.
-            if self.pk:
+        status_code = response.status_code
+        if status_code >= 400:
+            if status_code == 410 and self.pk:
+                # Their account got deleted, so let's do the same.
                 await Identity.objects.filter(pk=self.pk).adelete()
-            return False
-        if response.status_code == 404:
-            # We don't trust this as much as 410 Gone, but skip for now
-            return False
-        if response.status_code >= 500:
-            return False
-        if response.status_code >= 400:
+
+            if status_code >= 500 or status_code in [403, 404, 410]:
+                # Common errors with other server, not worth reporting
+                return False
+
             raise ValueError(
-                f"Client error fetching actor at {self.actor_uri}: {response.status_code}",
+                f"Client error fetching actor at {self.actor_uri}: {status_code}",
                 response.content,
             )
         document = canonicalise(response.json(), include_security=True)


### PR DESCRIPTION
Suppresses the follow errors:
* Invalid cert
* Forbidden responses
* Garbage (non-json dict) responses