### PR TITLE
Fix emoji file size validation and help text and add image size validation

### DIFF
--- a/users/views/admin/emoji.py
+++ b/users/views/admin/emoji.py
@@ -49,13 +49,15 @@ class EmojiCreate(FormView):
             help_text="What users type to use the emoji :likethis:",
         )
         image = forms.ImageField(
-            help_text="The emoji image\nShould be at least 40 x 40 pixels, and under 50kb",
+            help_text=f"The emoji image\nShould be at least 40 x 40 pixels, and under {settings.SETUP.EMOJI_MAX_IMAGE_FILESIZE_KB}KB",
         )
 
         def clean_image(self):
             data = self.cleaned_data["image"]
-            if data.size > settings.SETUP.EMOJI_MAX_IMAGE_FILESIZE_KB:
-                raise forms.ValidationError("Image filesize is too large")
+            if data.size > settings.SETUP.EMOJI_MAX_IMAGE_FILESIZE_KB * 1024:
+                raise forms.ValidationError(
+                    f"Image filesize is too large (actual: {data.size // 1024}KB)"
+                )
             return data
 
     def form_valid(self, form):

--- a/users/views/admin/emoji.py
+++ b/users/views/admin/emoji.py
@@ -58,6 +58,10 @@ class EmojiCreate(FormView):
                 raise forms.ValidationError(
                     f"Image filesize is too large (actual: {data.size // 1024}KB)"
                 )
+            if data.image.width < 40 or data.image.height < 40:
+                raise forms.ValidationError(
+                    f"Image should at least 40 x 40 pixels (actual: {data.image.width} x {data.image.height} pixels)"
+                )
             return data
 
     def form_valid(self, form):


### PR DESCRIPTION
Thanks for implementing the emoji admin page! 🙂 

I tried adding new emojis but it always returned "Image filesize is too large" error.

This PR fixes so that the size validation is performed correctly in KB, and amends the help text to show the actual file size limit in the settings.

Also, I added an image size (width/height, not file size) check as written in the help text.

## Validation error example
<img width="676" alt="Screenshot 2023-01-14 at 20 44 37" src="https://user-images.githubusercontent.com/1425259/212474242-37e3f1db-3f3e-4710-bb27-a7316bbe1fcf.png">
<img width="683" alt="Screenshot 2023-01-14 at 20 43 52" src="https://user-images.githubusercontent.com/1425259/212474243-97291931-19fd-4cec-8149-5b596a2eacfc.png">
