### PR TITLE
Support acct with domain name in /api/v1/accounts/lookup

### DIFF
--- a/api/views/accounts.py
+++ b/api/views/accounts.py
@@ -86,8 +86,8 @@ def lookup(request: HttpRequest, acct: str):
     Quickly lookup a username to see if it is available, skipping WebFinger
     resolution.
     """
-    acct = acct.lstrip("@")
     host = request.get_host()
+    acct = acct.lstrip("@").removesuffix(f"@{host}")
 
     identity = Identity.objects.filter(
         Q(domain__service_domain__iexact=host) | Q(domain__domain__iexact=host),


### PR DESCRIPTION
Mastodon supports all the following patterns:

- https://mastodon.social/api/v1/accounts/lookup?acct=mastodon
- https://mastodon.social/api/v1/accounts/lookup?acct=@mastodon
- https://mastodon.social/api/v1/accounts/lookup?acct=mastodon@mastodon.social
- https://mastodon.social/api/v1/accounts/lookup?acct=@mastodon@mastodon.social

but Takahē failed to return the last two patterns.

- https://takahe.social/api/v1/accounts/lookup?acct=admin
- https://takahe.social/api/v1/accounts/lookup?acct=@admin
- https://takahe.social/api/v1/accounts/lookup?acct=admin@takahe.social
- https://takahe.social/api/v1/accounts/lookup?acct=@admin@takahe.social

ref. accounts API methods - Mastodon documentation - https://docs.joinmastodon.org/methods/accounts/#lookup