### PR TITLE
Instruct robots to ignore proxy

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -3,3 +3,6 @@ User-Agent: *
 # Don't allow any bot to crawl tags.
 Disallow: /tags/
 Disallow: /tags/*
+
+# Don't allow bots to crawl through the proxy
+Disallow: /proxy/*


### PR DESCRIPTION
Robots are already crawling my takahē instance, which is fine, but crawling the proxy is a good way to burn bandwidth. Also Mastodon appears to have a similar block by default (e.g. https://mastodon.social/robots.txt)