### PR TITLE
Prevent uploading too large image file

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1034,6 +1034,7 @@ button.toggle,
 button[disabled],
 .button[disabled] {
     background: var(--color-button-disabled);
+    cursor: not-allowed;
 }
 
 button.left,

--- a/templates/activities/_image_upload.html
+++ b/templates/activities/_image_upload.html
@@ -9,7 +9,7 @@
     {% include "forms/_field.html" with field=form.image %}
     {% include "forms/_field.html" with field=form.description %}
     <div class="buttons">
-        <button _="on click show #attachmentProgress with display:block then hide me">Upload</button>
+        <button id="upload" _="on click show #attachmentProgress with display:block then hide me">Upload</button>
         <progress id="attachmentProgress" value="0" max="100"></progress>
     </div>
 </form>


### PR DESCRIPTION
resolves #392

Fortunately, `input[type=file]` holds the size information of the selected image, which can be checked with hyperscript.

> `size`
> The size of the file in bytes as a read-only 64-bit integer.

ref. [Using files from web applications - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/File_API/Using_files_from_web_applications#getting_information_about_selected_files)

This PR will put the same error message DOM in the same place as Django generates. It also prevents clicking the "Upload" button in a similar way as the character count feature.

**Accepted case (<= 10MB)**
<img width="642" alt="Screenshot 2023-01-15 at 14 30 53" src="https://user-images.githubusercontent.com/1425259/212524515-4b47a243-4210-4bd7-beb4-e58afdf0d038.png">

**Rejected case (> 10MB)**
<img width="646" alt="Screenshot 2023-01-15 at 14 30 33" src="https://user-images.githubusercontent.com/1425259/212524514-b0c45fed-f3ac-4f41-ae4b-b276263efc58.png">

(note: the orange color is green by default)