### PR TITLE
Render non-media PostAttachments

### DIFF
--- a/activities/models/post_attachment.py
+++ b/activities/models/post_attachment.py
@@ -73,7 +73,11 @@ class PostAttachment(StatorModel):
         ]
 
     def is_video(self):
-        return self.mimetype in ["video/webm"]
+        return self.mimetype in [
+            "video/mp4",
+            "video/ogg",
+            "video/webm",
+        ]
 
     def thumbnail_url(self) -> RelativeAbsoluteUrl:
         if self.thumbnail:
@@ -89,11 +93,20 @@ class PostAttachment(StatorModel):
     def full_url(self):
         if self.file:
             return RelativeAbsoluteUrl(self.file.url)
-        else:
+        if self.is_image():
             return ProxyAbsoluteUrl(
                 f"/proxy/post_attachment/{self.pk}/",
                 remote_url=self.remote_url,
             )
+        return RelativeAbsoluteUrl(self.remote_url)
+
+    @property
+    def file_display_name(self):
+        if self.remote_url:
+            return self.remote_url.rsplit("/", 1)[-1]
+        if self.file:
+            return self.file.name
+        return f"attachment ({self.mimetype})"
 
     ### ActivityPub ###
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1497,9 +1497,30 @@ form .post {
     max-width: 100%;
 }
 
-.post .content .attachments  a.non-media-file {
-    background-color: var(--color-bg-main);
-    padding: 5px 10px;
+.post .attachments .other {
+    grid-column: span 2;
+    padding: 8px;
+    border: 1px solid var(--color-text-duller);
+    background: var(--color-bg-menu);
+    border-radius: 4px;
+    margin-top: 8px;
+    word-break: break-all;
+}
+
+.post .attachments .other-label {
+    display: flex;
+    align-items: center;
+}
+
+.post .attachments .other-label > i {
+    margin-right: 12px;
+}
+
+.post .attachments .other:hover {
+    text-decoration: none;
+    background: var(--color-bg-main);
+    color: #FFF;
+    border-color: var(--color-highlight);
 }
 
 .post .actions {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1497,6 +1497,11 @@ form .post {
     max-width: 100%;
 }
 
+.post .content .attachments  a.non-media-file {
+    background-color: var(--color-bg-main);
+    padding: 5px 10px;
+}
+
 .post .actions {
     display: flex;
     position: relative;

--- a/templates/activities/_post.html
+++ b/templates/activities/_post.html
@@ -50,9 +50,11 @@
                     {% elif attachment.is_video %}
                         <a href="{{ attachment.full_url.relative }}" class="video">
                             <video muted controls loop>
-                                <source src="{{ attachment.full_url.relative }}">
+                                <source src="{{ attachment.full_url.relative }}" type="{{ attachment.mimetype }}">
                             </video>
                         </a>
+                    {% else %}
+                        <a href="{{ attachment.full_url }}" class="non-media-file" target="_blank">File: {{ attachment.file_display_name }}</a>
                     {% endif %}
                 {% endfor %}
             </div>

--- a/templates/activities/_post.html
+++ b/templates/activities/_post.html
@@ -53,8 +53,15 @@
                                 <source src="{{ attachment.full_url.relative }}" type="{{ attachment.mimetype }}">
                             </video>
                         </a>
-                    {% else %}
-                        <a href="{{ attachment.full_url }}" class="non-media-file" target="_blank">File: {{ attachment.file_display_name }}</a>
+                    {% endif %}
+                {% endfor %}
+                {% for attachment in post.attachments.all %}
+                    {% if not attachment.is_image and not attachment.is_video %}
+                        <a href="{{ attachment.full_url.relative }}" class="other">
+                            <div class="other-label">
+                                <i class="fa-solid fa-download"></i> {{ attachment.file_display_name }}
+                            </div>
+                        </a>
                     {% endif %}
                 {% endfor %}
             </div>


### PR DESCRIPTION
Only image and webm video attachments would show on a post. Adding mp4 and ogg to the list of supported `<video>` attachments and include non-proxied links to non-media attachments.