### PR TITLE
Match sanitizing for posts to Mastodon

### DIFF
--- a/tests/core/test_html.py
+++ b/tests/core/test_html.py
@@ -84,10 +84,10 @@ def test_list_rendering():
 
     assert (
         renderer.render_post(
-            '<p>Ok. The roster so far is:</p><ul><li>Infosec.exchange (mastodon)</li><li>pixel.Infosec.exchange (pixelfed)</li><li>video.Infosec.exchange (peertube)</li><li>relay.Infosec.exchange (activitypub relay)</li><li>risky.af (alt mastodon)</li></ul><p>What’s next?  I think I promised some people here bookwyrm</p>',
+            "<p>Ok. The roster so far is:</p><ul><li>Infosec.exchange (mastodon)</li><li>pixel.Infosec.exchange (pixelfed)</li><li>video.Infosec.exchange (peertube)</li><li>relay.Infosec.exchange (activitypub relay)</li><li>risky.af (alt mastodon)</li></ul><p>What’s next?  I think I promised some people here bookwyrm</p>",
             fake_post,
         )
-        == '<p>Ok. The roster so far is:</p><p>Infosec.exchange (mastodon)<br>pixel.Infosec.exchange (pixelfed)<br>video.Infosec.exchange (peertube)<br>relay.Infosec.exchange (activitypub relay)<br>risky.af (alt mastodon)</p><p>What’s next?  I think I promised some people here bookwyrm</p>'
+        == "<p>Ok. The roster so far is:</p><p>Infosec.exchange (mastodon)<br>pixel.Infosec.exchange (pixelfed)<br>video.Infosec.exchange (peertube)<br>relay.Infosec.exchange (activitypub relay)<br>risky.af (alt mastodon)</p><p>What’s next?  I think I promised some people here bookwyrm</p>"
     )
 
 

--- a/tests/core/test_html.py
+++ b/tests/core/test_html.py
@@ -65,6 +65,33 @@ def test_link_preservation():
 
 
 @pytest.mark.django_db
+def test_list_rendering():
+    """
+    We want to:
+     - Preserve incoming links from other servers
+     - Linkify mentions and hashtags
+     - Not have these all step on each other!
+    """
+    renderer = ContentRenderer(local=True)
+    fake_mention = Mock()
+    fake_mention.username = "andrew"
+    fake_mention.domain_id = "aeracode.org"
+    fake_mention.urls.view = "/@andrew@aeracode.org/"
+    fake_post = Mock()
+    fake_post.mentions.all.return_value = [fake_mention]
+    fake_post.author.domain.uri_domain = "example.com"
+    fake_post.emojis.all.return_value = []
+
+    assert (
+        renderer.render_post(
+            '<p>Ok. The roster so far is:</p><ul><li>Infosec.exchange (mastodon)</li><li>pixel.Infosec.exchange (pixelfed)</li><li>video.Infosec.exchange (peertube)</li><li>relay.Infosec.exchange (activitypub relay)</li><li>risky.af (alt mastodon)</li></ul><p>What’s next?  I think I promised some people here bookwyrm</p>',
+            fake_post,
+        )
+        == '<p>Ok. The roster so far is:</p><p>Infosec.exchange (mastodon)<br>pixel.Infosec.exchange (pixelfed)<br>video.Infosec.exchange (peertube)<br>relay.Infosec.exchange (activitypub relay)<br>risky.af (alt mastodon)</p><p>What’s next?  I think I promised some people here bookwyrm</p>'
+    )
+
+
+@pytest.mark.django_db
 def test_link_mixcase_mentions():
     renderer = ContentRenderer(local=True)
     fake_mention = Mock()


### PR DESCRIPTION
Creates filter for REWRITTEN_TAGS that converts them to `p` rather than ripping them out entirely, and formats `ul` as break-separated list

Both changes align sanitization to Mastodon's "strict" sanitizer at https://github.com/mastodon/mastodon/blob/main/lib/sanitize_ext/sanitize_config.rb#L73

I don't love the complexity of the Filter, but Bleach doesn't give us great options to work with. The code operates within an iterator without the useful "sibling" methods that Ruby's equivalent has. Also, Bleach runs filters _after_ sanitizing (unlike Ruby's which runs before) so we have to pass all the elements through the sanitizer, then rewrite them after the fact.

Content with the issue (from Jerry on a Glitch instance, edited to add newlines for readability as raw content has no newlines):
```html
<p>Ok. The roster so far is:</p>
<ul>
<li>Infosec.exchange (mastodon)</li>
<li>pixel.Infosec.exchange (pixelfed)</li>
<li>video.Infosec.exchange (peertube)</li>
<li>relay.Infosec.exchange (activitypub relay)</li>
<li>risky.af (alt mastodon)</li>
</ul>
<p>What’s next?  I think I promised some people here bookwyrm</p>
```

Takahē's flawed rendering (with newlines added):
```html
<p>Ok. The roster so far is:</p>
Infosec.exchange (mastodon)pixel.Infosec.exchange (pixelfed)video.Infosec.exchange (peertube)relay.Infosec.exchange (activitypub relay)risky.af (alt mastodon)
<p>What’s next?  I think I promised some people here bookwyrm</p>
```

And the canonical HTML from Mastodon (edited to add newlines):
```html
<p>Ok. The roster so far is:</p>
<p>Infosec.exchange (mastodon)
<br>pixel.Infosec.exchange (pixelfed)
<br>video.Infosec.exchange (peertube)
<br>relay.Infosec.exchange (activitypub relay)
<br>risky.af (alt mastodon)
</p>
<p>What’s next?  I think I promised some people here bookwyrm</p>
```

Image version:

- [Canonical rendering on Mastodon.social](https://mastodon.social/@jerry@infosec.exchange/109696283396436196)
 ![Canonical rendering](https://user-images.githubusercontent.com/456754/212601446-7526a73f-b885-4f2d-befe-5b34313d65b3.png)
- [Rendering on Takahē without patch](https://takahe.tabletcorry.com/@jerry@infosec.exchange/posts/137623723713110768/)
 ![Takahē without patch](https://user-images.githubusercontent.com/456754/212601481-95e0724c-25f0-48af-a2a0-71d805610f11.png)

Notes:

- Lists aren't  actually possible except from users of the glitch fork (as Jerry is here). Glitch fork will render the list using HTML properly (with bullets), but mainline versions of Mastodon will use the `<br>` method implemented in this patch. At some point Takahē should consider if they want to support any glitch fork features.
- This _doesn't_ enable spans because that causes issues with hashtag parsing. That will need to be a followup PR.