### PR TITLE
Ignore non string attachment mimetypes

### DIFF
--- a/activities/models/post.py
+++ b/activities/models/post.py
@@ -843,7 +843,7 @@ class Post(StatorModel):
                 else:
                     focal_x, focal_y = None, None
                 mimetype = attachment.get("mediaType")
-                if not mimetype:
+                if not mimetype or not isinstance(mimetype, str):
                     mimetype, _ = mimetypes.guess_type(attachment["url"])
                     if not mimetype:
                         mimetype = "application/octet-stream"


### PR DESCRIPTION
This should bypass many of the issues related to LD mishaps with post attachment mimetypes.