### PR TITLE
Fix navbar not scrolling in mobile

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1733,6 +1733,7 @@ form .post {
         height: 100%;
         right: 0;
         top: var(--md-header-height);
+        overflow-y: auto;
     }
 
     .right-column nav {


### PR DESCRIPTION
In the mobile version when we open the administration area the options go over the screen height and can't be reached.