### PR TITLE
Show image at normal size when less than width 100%

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1512,7 +1512,6 @@ form .post {
     object-fit: cover;
     object-position: center;
     max-height: 400px;
-    width: 100%;
 }
 
 .post .attachments video {


### PR DESCRIPTION
This `width: 100%;` causes images smaller than `width: 100%;` with a height < 400px to scale up to be 400px tall. This causes normally viewable images to either become blurry or clipped, forcing a click to view at normal scaling.