### PR TITLE
Handle nodeinfo validation errors

### DIFF
--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -16,26 +16,30 @@ class ActorMismatchError(ActivityPubError):
     """
 
 
-def capture_message(message: str):
+def capture_message(message: str, level: str | None = None, scope=None, **scope_args):
     """
     Sends the informational message to Sentry if it's configured
     """
     if settings.SETUP.SENTRY_DSN and settings.SETUP.SENTRY_CAPTURE_MESSAGES:
         from sentry_sdk import capture_message
 
-        capture_message(message)
+        capture_message(message, level, scope, **scope_args)
     elif settings.DEBUG:
+        if scope or scope_args:
+            message += f"; {scope=}, {scope_args=}"
         print(message)
 
 
-def capture_exception(exception: BaseException):
+def capture_exception(
+    exception: BaseException, level: str | None = None, scope=None, **scope_args
+):
     """
     Sends the exception to Sentry if it's configured
     """
     if settings.SETUP.SENTRY_DSN:
         from sentry_sdk import capture_exception
 
-        capture_exception(exception)
+        capture_exception(exception, level, scope, **scope_args)
     elif settings.DEBUG:
         traceback.print_exc()
 

--- a/users/models/domain.py
+++ b/users/models/domain.py
@@ -3,6 +3,7 @@ import ssl
 from typing import Optional
 
 import httpx
+import pydantic
 import urlman
 from asgiref.sync import sync_to_async
 from django.conf import settings
@@ -202,9 +203,13 @@ class Domain(StatorModel):
 
             try:
                 info = NodeInfo(**response.json())
-            except json.JSONDecodeError as ex:
+            except (json.JSONDecodeError, pydantic.ValidationError) as ex:
                 capture_message(
-                    f"Client error decoding nodeinfo: domain={self.domain}, error={str(ex)}"
+                    f"Client error decoding nodeinfo: {str(ex)}",
+                    extra={
+                        "domain": self.domain,
+                        "nodeinfo20_url": nodeinfo20_url,
+                    },
                 )
                 return None
             return info

--- a/users/schemas.py
+++ b/users/schemas.py
@@ -14,7 +14,7 @@ class NodeInfoSoftware(BaseModel):
 
 
 class NodeInfoUsage(BaseModel):
-    users: dict[str, int] | None
+    users: dict[str, int | None] | None
     local_posts: int = Field(default=0, alias="localPosts")
 
 


### PR DESCRIPTION
Version 13 of misskey returns nulls for the user usage stats in some instances. Might be a bug or behavior change in their latest version.