### PR TITLE
Downgrade most fetch related errors to capture_message

### DIFF
--- a/activities/models/post.py
+++ b/activities/models/post.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import mimetypes
 import re
+import ssl
 from collections.abc import Iterable
 from typing import Optional
 from urllib.parse import urlparse
@@ -890,7 +891,7 @@ class Post(StatorModel):
                     response = async_to_sync(SystemActor().signed_request)(
                         method="get", uri=object_uri
                     )
-                except httpx.RequestError:
+                except (httpx.HTTPError, ssl.SSLCertVerificationError):
                     raise cls.DoesNotExist(f"Could not fetch {object_uri}")
                 if response.status_code in [404, 410]:
                     raise cls.DoesNotExist(f"No post at {object_uri}")

--- a/users/models/domain.py
+++ b/users/models/domain.py
@@ -195,9 +195,14 @@ class Domain(StatorModel):
                     and response.status_code < 500
                     and response.status_code not in [401, 403, 404, 406, 410]
                 ):
-                    raise ValueError(
-                        f"Client error fetching nodeinfo: domain={self.domain}, code={response.status_code}",
-                        response.content,
+                    capture_message(
+                        f"Client error fetching nodeinfo: {str(ex)}",
+                        extras={
+                            "code": response.status_code,
+                            "content": response.content,
+                            "domain": self.domain,
+                            "nodeinfo20_url": nodeinfo20_url,
+                        },
                     )
                 return None
 
@@ -206,7 +211,7 @@ class Domain(StatorModel):
             except (json.JSONDecodeError, pydantic.ValidationError) as ex:
                 capture_message(
                     f"Client error decoding nodeinfo: {str(ex)}",
-                    extra={
+                    extras={
                         "domain": self.domain,
                         "nodeinfo20_url": nodeinfo20_url,
                     },


### PR DESCRIPTION
I feel confident that we've hit the point where any HTTP level errors are not something we need to act upon and are safe to disable when not explicitly wanting to see them. I have this soaking on my instance to make sure it clears all the current nuisance errors.