### PR TITLE
Fix highlight color in the light theme

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -14,7 +14,7 @@
         <script src="{% static "js/htmx.min.js" %}"></script>
         <script src="{% static "js/takahe.min.js" %}"></script>
         <style>
-            body {
+            body, body.light-theme {
                 --color-highlight: {{ config.highlight_color }};
                 --color-text-link: {{ config.highlight_color }};
             }


### PR DESCRIPTION
The CSS variables like `--color-highlight` was defined `:root` and overridden by `body.light-theme`. That disabled the custom highlight color setting in the light theme.

This change ensures the highlight color in both themes.