### PR TITLE
Allow auto-pagination on profile page

### DIFF
--- a/templates/identity/view.html
+++ b/templates/identity/view.html
@@ -103,11 +103,15 @@
                 </span>
             {% endfor %}
 
-            {% if page_obj.has_next %}
-                <div class="pagination">
-                    <a class="button" href=".?page={{ page_obj.next_page_number }}">Next Page</a>
-                </div>
-            {% endif %}
+            <div class="pagination">
+                {% if page_obj.has_previous and not request.htmx %}
+                    <a class="button" href=".?page={{ page_obj.previous_page_number }}">Previous Page</a>
+                {% endif %}
+
+                {% if page_obj.has_next %}
+                    <a class="button" href=".?page={{ page_obj.next_page_number }}" hx-get=".?page={{ page_obj.next_page_number }}" hx-select=".left-column > *:not(.view-options)" hx-target=".pagination" hx-swap="outerHTML" {% if config_identity.infinite_scroll %}hx-trigger="revealed"{% endif %}>Next Page</a>
+                {% endif %}
+            </div>
 
         {% endblock %}
     {% endif %}


### PR DESCRIPTION
Auto-pagination feature is very useful but it didn't work on profile page such as https://takahe.social/@takahe@jointakahe.org/.