### PR TITLE
Fix "Add image" button margin

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -999,11 +999,11 @@ form fieldset .buttons {
     margin-top: 0;
 }
 
-form .button.add-image {
+form button.add-image {
     margin: 10px 0 10px 0;
 }
 
-form legend+.button.add-image {
+form legend+button.add-image {
     margin-top: 0px;
 }
 


### PR DESCRIPTION
Sorry, this was a regression introduced by my keyboard navigation fix #373.

**Before**
<img width="693" alt="Screenshot 2023-01-19 at 18 58 49" src="https://user-images.githubusercontent.com/1425259/213414279-24aca1a6-2791-4e61-80da-df8bb296bd22.png">

**After**
<img width="707" alt="Screenshot 2023-01-19 at 18 58 41" src="https://user-images.githubusercontent.com/1425259/213414282-3f268fcf-de56-46e3-baa6-c4ce038be784.png">
