### PR TITLE
Attach user identification headers to response

### DIFF
--- a/docker/nginx.conf.d/default.conf.tpl
+++ b/docker/nginx.conf.d/default.conf.tpl
@@ -25,6 +25,10 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_http_version 1.1;
 
+    # The user header is available for logging, but not returned to the client
+    proxy_hide_header X-Takahe-User;
+    proxy_hide_header X-Takahe-User-Identity;
+
     # Serve robots.txt from the non-collected dir as a special case.
     location /robots.txt {
         alias /takahe/static/robots.txt;

--- a/docker/nginx.conf.d/default.conf.tpl
+++ b/docker/nginx.conf.d/default.conf.tpl
@@ -27,7 +27,7 @@ server {
 
     # The user header is available for logging, but not returned to the client
     proxy_hide_header X-Takahe-User;
-    proxy_hide_header X-Takahe-User-Identity;
+    proxy_hide_header X-Takahe-Identity;
 
     # Serve robots.txt from the non-collected dir as a special case.
     location /robots.txt {

--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -216,6 +216,7 @@ MIDDLEWARE = [
     "core.middleware.ConfigLoadingMiddleware",
     "api.middleware.ApiTokenMiddleware",
     "users.middleware.IdentityMiddleware",
+    "users.middleware.UserHeaderMiddleware",
 ]
 
 ROOT_URLCONF = "takahe.urls"

--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -216,7 +216,6 @@ MIDDLEWARE = [
     "core.middleware.ConfigLoadingMiddleware",
     "api.middleware.ApiTokenMiddleware",
     "users.middleware.IdentityMiddleware",
-    "users.middleware.UserHeaderMiddleware",
 ]
 
 ROOT_URLCONF = "takahe.urls"

--- a/users/middleware.py
+++ b/users/middleware.py
@@ -30,21 +30,6 @@ class IdentityMiddleware:
                     request.identity = None
 
         response = self.get_response(request)
-        return response
-
-
-class UserHeaderMiddleware:
-    """
-    Adds X-Takahe-User and X-Takahe-Identity headers to the response, identifying the user/identity as available.
-
-    These are stripped away from the response by Nginx, so they exist to enrich logging in Nginx when required/desired.
-    """
-
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        response = self.get_response(request)
 
         if request.user:
             response.headers["X-Takahe-User"] = str(request.user)

--- a/users/middleware.py
+++ b/users/middleware.py
@@ -31,3 +31,24 @@ class IdentityMiddleware:
 
         response = self.get_response(request)
         return response
+
+
+class UserHeaderMiddleware:
+    """
+    Adds X-Takahe-User and X-Takahe-User-Identity headers to the response, identifying the user/identity as available.
+
+    These are stripped away from the response by Nginx, so they exist to enrich logging in Nginx when required/desired.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        if request.user:
+            response.headers["X-Takahe-User"] = str(request.user)
+        if request.identity:
+            response.headers["X-Takahe-User-Identity"] = str(request.identity)
+
+        return response

--- a/users/middleware.py
+++ b/users/middleware.py
@@ -35,7 +35,7 @@ class IdentityMiddleware:
 
 class UserHeaderMiddleware:
     """
-    Adds X-Takahe-User and X-Takahe-User-Identity headers to the response, identifying the user/identity as available.
+    Adds X-Takahe-User and X-Takahe-Identity headers to the response, identifying the user/identity as available.
 
     These are stripped away from the response by Nginx, so they exist to enrich logging in Nginx when required/desired.
     """

--- a/users/middleware.py
+++ b/users/middleware.py
@@ -49,6 +49,6 @@ class UserHeaderMiddleware:
         if request.user:
             response.headers["X-Takahe-User"] = str(request.user)
         if request.identity:
-            response.headers["X-Takahe-User-Identity"] = str(request.identity)
+            response.headers["X-Takahe-Identity"] = str(request.identity)
 
         return response


### PR DESCRIPTION
Add `X-Takahe-User` and `X-Takahe-Identity` headers to response, when available, to allow for better Nginx log enrichment.

Also drop these headers in Nginx so they aren't sent into the world. They probably aren't dangerous since they identfy the users _to themselves_ but strip it for now, just in case.