### PR TITLE
Add missing trailing slash to the copy command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ COPY docker/mime.types /etc/mime.types
 
 # Configure nginx
 COPY docker/nginx.conf /etc/nginx/
-COPY docker/nginx.conf.d/* /etc/nginx/conf.d
+COPY docker/nginx.conf.d/* /etc/nginx/conf.d/
 
 COPY . /takahe
 


### PR DESCRIPTION
Small fix adding the missing trailing slash to fix docker build image step 11:

```
Step 11/18 : COPY docker/nginx.conf.d/* /etc/nginx/conf.d
When using COPY with more than one source file, the destination must be a directory and end with a /
make: *** [Makefile:4: image] Error 1
```