### PR TITLE
Remove capture message for deleting unknown actor

### DIFF
--- a/users/views/activitypub.py
+++ b/users/views/activitypub.py
@@ -135,9 +135,6 @@ class Inbox(View):
             and identity._state.adding
         ):
             # We don't have an Identity record for the user. No-op
-            exceptions.capture_message(
-                f"Inbox: Discarded delete message for unknown actor {document['actor']}"
-            )
             return HttpResponse(status=202)
 
         if not identity.public_key:


### PR DESCRIPTION
Mastodon fans out actor deletes so frequently this message provides little to no value.