### PR TITLE
Fix issue where CW button on menu compose form submits the form

### DIFF
--- a/templates/activities/_menu.html
+++ b/templates/activities/_menu.html
@@ -64,7 +64,7 @@
         <input type="hidden" name="visibility" value="{{ config_identity.default_post_visibility }}">
         <div class="buttons">
             <span id="character-counter">{{ config.post_length }}</span>
-            <button class="toggle" _="on click or keyup[key is 'Enter'] toggle .enabled then toggle .hidden on #id_content_warning">CW</button>
+            <button class="toggle" _="on click or keyup[key is 'Enter'] toggle .enabled then toggle .hidden on #id_content_warning then halt">CW</button>
             <button id="post-button">{% if config_identity.toot_mode %}Toot!{% else %}Post{% endif %}</button>
         </div>
     </form>


### PR DESCRIPTION
Clicking the `CW` button submits the form when it shouldn't.