### PR TITLE
Make user handle search to be case insensitive

### DIFF
--- a/activities/services/search.py
+++ b/activities/services/search.py
@@ -59,7 +59,7 @@ class SearchService:
         else:
             for identity in Identity.objects.filter(username=handle)[:20]:
                 results.add(identity)
-            for identity in Identity.objects.filter(username__startswith=handle)[:20]:
+            for identity in Identity.objects.filter(username__istartswith=handle)[:20]:
                 results.add(identity)
         return results
 


### PR DESCRIPTION
Mastodon API is case-insensitive when looking up user handles.