### PR TITLE
Fix wrong post character counting in hyperscript

### DIFF
--- a/activities/views/compose.py
+++ b/activities/views/compose.py
@@ -59,7 +59,7 @@ class Compose(FormView):
             self.request = request
             self.fields["text"].widget.attrs[
                 "_"
-            ] = f"""
+            ] = rf"""
                 init
                     -- Move cursor to the end of existing text
                     set my.selectionStart to my.value.length
@@ -67,7 +67,8 @@ class Compose(FormView):
 
                 on load or input
                 -- Unicode-aware counting to match Python
-                set characters to Array.from(my.value.trim()).length
+                -- <LF> will be normalized as <CR><LF> in Django
+                set characters to Array.from(my.value.replaceAll('\n','\r\n').trim()).length
                 put {Config.system.post_length} - characters into #character-counter
 
                 if characters > {Config.system.post_length} then


### PR DESCRIPTION
resolves #460

A newline `\n` will be normalized as `\r\n` in Django.

**Before**
<img width="705" alt="Screenshot 2023-01-28 at 1 23 01" src="https://user-images.githubusercontent.com/1425259/215143053-3909a29c-794f-4a04-b578-2f9bce35a5ff.png">

**After**
<img width="706" alt="Screenshot 2023-01-28 at 1 32 45" src="https://user-images.githubusercontent.com/1425259/215143065-dc8147a6-6b37-4030-bfb7-53edd6411777.png">
