### PR TITLE
also read query string params in parse body

### DIFF
--- a/api/parser.py
+++ b/api/parser.py
@@ -17,4 +17,6 @@ class FormOrJsonParser(Parser):
         value = {}
         for key, item in request.POST.items():
             value[key] = item
+        for key, item in request.GET.items():
+            value[key] = item
         return value


### PR DESCRIPTION
Upon digging into #290 after finally getting access to Mammoth I realized that it is sending the params for `/oauth/token` in the query string instead. This is apparently valid for Mastodon. Per the Mastodon API docs

> Query strings, form data, and JSON submitted via POST body are equally understood by the API. 

While it then states that it expects query strings to be used for GET and form data or JSON to be used for other requests, nothing enforces this and therefore clients can depend on it. Furthermore it seems this is the default behavior in Rails where query string and body params are combined together into a single `params` hash.

Therefore to maximize API compatibility let's do the same thing and fallback to reading query string params in `FormOrJsonParser`.

Fixes #290