### PR TITLE
Fix header duplication during infinity scroll

### DIFF
--- a/templates/identity/view.html
+++ b/templates/identity/view.html
@@ -15,7 +15,7 @@
 {% block body_class %}has-banner{% endblock %}
 
 {% block content %}
-    {% if not headless %}
+    {% if not request.htmx %}
         <h1 class="identity">
             {% if identity.local_image_url %}
                 <img src="{{ identity.local_image_url.relative }}" class="banner">
@@ -48,7 +48,7 @@
         </p>
     {% else %}
 
-        {% if not headless %}
+        {% if not request.htmx %}
             {% if identity.summary %}
                 <div class="bio">
                     {{ identity.safe_summary }}
@@ -113,7 +113,7 @@
                 {% endif %}
 
                 {% if page_obj.has_next %}
-                    <a class="button" href=".?page={{ page_obj.next_page_number }}" hx-get=".?page={{ page_obj.next_page_number }}&headless=true" hx-select=".left-column > *:not(.view-options)" hx-target=".pagination" hx-swap="outerHTML" {% if config_identity.infinite_scroll %}hx-trigger="revealed"{% endif %}>Next Page</a>
+                    <a class="button" href=".?page={{ page_obj.next_page_number }}" hx-get=".?page={{ page_obj.next_page_number }}" hx-select=".left-column > *:not(.view-options)" hx-target=".pagination" hx-swap="outerHTML" {% if config_identity.infinite_scroll %}hx-trigger="revealed"{% endif %}>Next Page</a>
                 {% endif %}
             </div>
 

--- a/templates/identity/view.html
+++ b/templates/identity/view.html
@@ -15,30 +15,32 @@
 {% block body_class %}has-banner{% endblock %}
 
 {% block content %}
-    <h1 class="identity">
-        {% if identity.local_image_url %}
-            <img src="{{ identity.local_image_url.relative }}" class="banner">
-        {% endif %}
+    {% if not headless %}
+        <h1 class="identity">
+            {% if identity.local_image_url %}
+                <img src="{{ identity.local_image_url.relative }}" class="banner">
+            {% endif %}
 
-        <img src="{{ identity.local_icon_url.relative }}" class="icon">
+            <img src="{{ identity.local_icon_url.relative }}" class="icon">
 
-        {% if request.identity %}{% include "identity/_view_menu.html" %}{% endif %}
+            {% if request.identity %}{% include "identity/_view_menu.html" %}{% endif %}
 
-        {{ identity.html_name_or_handle }}
-        <small>
-            @{{ identity.handle }}
-            <a title="Copy handle"
-                class="copy"
-                tabindex="0"
-                _="on click or keyup[key is 'Enter']
-                    writeText('@{{ identity.handle }}') into the navigator's clipboard
-                    then add .copied
-                    wait 2s
-                    then remove .copied">
-                <i class="fa-solid fa-copy"></i>
-            </a>
-        </small>
-    </h1>
+            {{ identity.html_name_or_handle }}
+            <small>
+                @{{ identity.handle }}
+                <a title="Copy handle"
+                    class="copy"
+                    tabindex="0"
+                    _="on click or keyup[key is 'Enter']
+                        writeText('@{{ identity.handle }}') into the navigator's clipboard
+                        then add .copied
+                        wait 2s
+                        then remove .copied">
+                    <i class="fa-solid fa-copy"></i>
+                </a>
+            </small>
+        </h1>
+    {% endif %}
 
     {% if inbound_block %}
         <p class="system-note">
@@ -46,41 +48,43 @@
         </p>
     {% else %}
 
-        {% if identity.summary %}
-            <div class="bio">
-                {{ identity.safe_summary }}
-            </div>
-        {% endif %}
+        {% if not headless %}
+            {% if identity.summary %}
+                <div class="bio">
+                    {{ identity.safe_summary }}
+                </div>
+            {% endif %}
 
-        {% if identity.metadata %}
-            <div class="identity-metadata">
-                {% for entry in identity.safe_metadata %}
-                    <div class="metadata-pair">
-                        <span class="metadata-name">{{ entry.name }}</span>
-                        <span class="metadata-value">{{ entry.value }}</span>
-                    </div>
-                {% endfor %}
-            </div>
-        {% endif %}
+            {% if identity.metadata %}
+                <div class="identity-metadata">
+                    {% for entry in identity.safe_metadata %}
+                        <div class="metadata-pair">
+                            <span class="metadata-name">{{ entry.name }}</span>
+                            <span class="metadata-value">{{ entry.value }}</span>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% endif %}
 
-        {% if identity.local and identity.config_identity.visible_follows %}
-            <div class="view-options follows">
-                <a href="{{ identity.urls.view }}" {% if not follows_page %}class="selected"{% endif %}><strong>{{ post_count }}</strong> posts</a>
-                <a href="{{ identity.urls.following }}" {% if not inbound and follows_page %}class="selected"{% endif %}><strong>{{ following_count }}</strong> following</a>
-                <a href="{{ identity.urls.followers }}" {% if inbound and follows_page %}class="selected"{% endif %}><strong>{{ followers_count }}</strong> follower{{ followers_count|pluralize }}</a>
-            </div>
-        {% endif %}
+            {% if identity.local and identity.config_identity.visible_follows %}
+                <div class="view-options follows">
+                    <a href="{{ identity.urls.view }}" {% if not follows_page %}class="selected"{% endif %}><strong>{{ post_count }}</strong> posts</a>
+                    <a href="{{ identity.urls.following }}" {% if not inbound and follows_page %}class="selected"{% endif %}><strong>{{ following_count }}</strong> following</a>
+                    <a href="{{ identity.urls.followers }}" {% if inbound and follows_page %}class="selected"{% endif %}><strong>{{ followers_count }}</strong> follower{{ followers_count|pluralize }}</a>
+                </div>
+            {% endif %}
 
-        {% if not identity.local %}
-            {% if identity.outdated and not identity.name %}
-                <p class="system-note">
-                    The system is still fetching this profile. Refresh to see updates.
-                </p>
-            {% else %}
-                <p class="system-note">
-                    This is a member of another server.
-                    <a href="{{ identity.profile_uri|default:identity.actor_uri }}">See their original profile ➔</a>
-                </p>
+            {% if not identity.local %}
+                {% if identity.outdated and not identity.name %}
+                    <p class="system-note">
+                        The system is still fetching this profile. Refresh to see updates.
+                    </p>
+                {% else %}
+                    <p class="system-note">
+                        This is a member of another server.
+                        <a href="{{ identity.profile_uri|default:identity.actor_uri }}">See their original profile ➔</a>
+                    </p>
+                {% endif %}
             {% endif %}
         {% endif %}
 
@@ -109,7 +113,7 @@
                 {% endif %}
 
                 {% if page_obj.has_next %}
-                    <a class="button" href=".?page={{ page_obj.next_page_number }}" hx-get=".?page={{ page_obj.next_page_number }}" hx-select=".left-column > *:not(.view-options)" hx-target=".pagination" hx-swap="outerHTML" {% if config_identity.infinite_scroll %}hx-trigger="revealed"{% endif %}>Next Page</a>
+                    <a class="button" href=".?page={{ page_obj.next_page_number }}" hx-get=".?page={{ page_obj.next_page_number }}&headless=true" hx-select=".left-column > *:not(.view-options)" hx-target=".pagination" hx-swap="outerHTML" {% if config_identity.infinite_scroll %}hx-trigger="revealed"{% endif %}>Next Page</a>
                 {% endif %}
             </div>
 

--- a/users/views/identity.py
+++ b/users/views/identity.py
@@ -69,7 +69,6 @@ class ViewIdentity(ListView):
 
     def get_context_data(self):
         context = super().get_context_data()
-        context["headless"] = self.request.GET.get("headless")
         context["identity"] = self.identity
         context["interactions"] = PostInteraction.get_post_interactions(
             context["page_obj"],

--- a/users/views/identity.py
+++ b/users/views/identity.py
@@ -69,6 +69,7 @@ class ViewIdentity(ListView):
 
     def get_context_data(self):
         context = super().get_context_data()
+        context["headless"] = self.request.GET.get("headless")
         context["identity"] = self.identity
         context["interactions"] = PostInteraction.get_post_interactions(
             context["page_obj"],


### PR DESCRIPTION
The infinity scroll at the Identity page was duplicating the header in each pagination event