### PR TITLE
Update _test_settings fixture to work with Django 4.1 and 4.2

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,9 @@ kwIDAQAB
 
 @pytest.fixture(autouse=True)
 def _test_settings(settings):
-    settings.STATICFILES_STORAGE = None
+    settings.STATICFILES_STORAGE = (
+        "django.contrib.staticfiles.storage.StaticFilesStorage"
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
With the `STORAGES` changes landing in Django 4.2, it is no longer happy with setting the (deprecated) `STATICFILES_STORAGE = None`. This fixture change is all that is necessary to run the tests against Django 4.2a1.