### PR TITLE
Fix CSV export to export followers handle instead of following user handle

### DIFF
--- a/tests/users/views/test_import_export.py
+++ b/tests/users/views/test_import_export.py
@@ -64,3 +64,23 @@ def test_export_following(
         response.content.strip()
         == b"Account address,Show boosts,Notify on new posts,Languages\r\ntest@remote.test,true,false,"
     )
+
+
+@pytest.mark.django_db
+def test_export_followers(
+    client_with_identity: Client,
+    identity: Identity,
+    identity2: Identity,
+    stator: StatorRunner,
+    httpx_mock: HTTPXMock,
+):
+    """
+    Validates the "export a CSV of your follows" functionality works
+    """
+    # Follow remote_identity
+    IdentityService(identity2).follow(identity)
+
+    # Download the CSV
+    response = client_with_identity.get("/settings/import_export/followers.csv")
+    assert response.status_code == 200
+    assert response.content.strip() == b"Account address\r\ntest@example2.com"

--- a/users/views/settings/import_export.py
+++ b/users/views/settings/import_export.py
@@ -151,4 +151,4 @@ class CsvFollowers(CsvView):
         return self.request.identity.inbound_follows.active()
 
     def get_handle(self, follow: Follow):
-        return follow.target.handle
+        return follow.source.handle


### PR DESCRIPTION
resolves #508

Let's say I'm "User A". When "User B" follows "User A", it creates a Follow like `<Follow: #148337992523677940: userB@takahe.social → userA@takahe.social>` (source -> target)

So to create a list of my followers, I need to use `follow.source.handle` instead of `follow.target.handle` to get a follower's handle name.