### PR TITLE
Fix hashtag being handled as common link in the preview card

### DIFF
--- a/core/html.py
+++ b/core/html.py
@@ -200,9 +200,9 @@ class FediverseHtmlParser(HTMLParser):
         hashtag = hashtag.lstrip("#")
         self.hashtags.add(hashtag.lower())
         if self.uri_domain:
-            return f'<a href="https://{self.uri_domain}/tags/{hashtag.lower()}/">#{hashtag}</a>'
+            return f'<a href="https://{self.uri_domain}/tags/{hashtag.lower()}/">#<span>{hashtag}</span></a>'
         else:
-            return f'<a href="/tags/{hashtag.lower()}/">#{hashtag}</a>'
+            return f'<a href="/tags/{hashtag.lower()}/">#<span>{hashtag}</span></a>'
 
     def create_emoji(self, shortcode) -> str:
         """

--- a/core/html.py
+++ b/core/html.py
@@ -200,9 +200,9 @@ class FediverseHtmlParser(HTMLParser):
         hashtag = hashtag.lstrip("#")
         self.hashtags.add(hashtag.lower())
         if self.uri_domain:
-            return f'<a href="https://{self.uri_domain}/tags/{hashtag.lower()}/">#<span>{hashtag}</span></a>'
+            return f'<a class="mention hashtag status-link" href="https://{self.uri_domain}/tags/{hashtag.lower()}/">#{hashtag}</a>'
         else:
-            return f'<a href="/tags/{hashtag.lower()}/">#<span>{hashtag}</span></a>'
+            return f'<a class="mention hashtag status-link" href="/tags/{hashtag.lower()}/">#{hashtag}</a>'
 
     def create_emoji(self, shortcode) -> str:
         """

--- a/core/html.py
+++ b/core/html.py
@@ -200,9 +200,9 @@ class FediverseHtmlParser(HTMLParser):
         hashtag = hashtag.lstrip("#")
         self.hashtags.add(hashtag.lower())
         if self.uri_domain:
-            return f'<a class="mention hashtag status-link" href="https://{self.uri_domain}/tags/{hashtag.lower()}/">#{hashtag}</a>'
+            return f'<a href="https://{self.uri_domain}/tags/{hashtag.lower()}/" rel="tag">#{hashtag}</a>'
         else:
-            return f'<a class="mention hashtag status-link" href="/tags/{hashtag.lower()}/">#{hashtag}</a>'
+            return f'<a href="/tags/{hashtag.lower()}/" rel="tag">#{hashtag}</a>'
 
     def create_emoji(self, shortcode) -> str:
         """

--- a/tests/activities/models/test_post.py
+++ b/tests/activities/models/test_post.py
@@ -448,3 +448,4 @@ def test_post_hashtag_to_ap(identity: Identity, config_system):
         }
     ]
     assert "#world" in ap["object"]["content"]
+    assert 'rel="tag"' in ap["object"]["content"]

--- a/tests/activities/models/test_post.py
+++ b/tests/activities/models/test_post.py
@@ -447,4 +447,4 @@ def test_post_hashtag_to_ap(identity: Identity, config_system):
             "type": "Hashtag",
         }
     ]
-    assert "#<span>world</span>" in ap["object"]["content"]
+    assert "#world" in ap["object"]["content"]

--- a/tests/activities/models/test_post.py
+++ b/tests/activities/models/test_post.py
@@ -429,3 +429,22 @@ def test_inbound_posts(
     # Run stator and ensure that deleted the post
     stator.run_single_cycle_sync()
     assert not Post.objects.filter(object_uri="https://remote.test/test-post").exists()
+
+
+@pytest.mark.django_db
+def test_post_hashtag_to_ap(identity: Identity, config_system):
+    """
+    Tests post hashtags conversion to AP format.
+    """
+    post = Post.create_local(author=identity, content="Hello #world")
+    assert post.hashtags == ["world"]
+
+    ap = post.to_create_ap()
+    assert ap["object"]["tag"] == [
+        {
+            "href": "https://example.com/tags/world/",
+            "name": "#world",
+            "type": "Hashtag",
+        }
+    ]
+    assert "#<span>world</span>" in ap["object"]["content"]

--- a/tests/core/test_html.py
+++ b/tests/core/test_html.py
@@ -102,7 +102,7 @@ def test_parser(identity):
     )
     assert (
         parser.html
-        == '<a href="http://example.com#notahashtag" rel="nofollow">something</a> <a href="/tags/hashtag/">#hashtag</a> <a href="/tags/hashtagtwo/">#hashtagtwo</a>'
+        == '<a href="http://example.com#notahashtag" rel="nofollow">something</a> <a href="/tags/hashtag/" rel="tag">#hashtag</a> <a href="/tags/hashtagtwo/" rel="tag">#hashtagtwo</a>'
     )
     assert parser.plain_text == "http://example.com#notahashtag #hashtag #hashtagtwo"
     assert parser.hashtags == {"hashtag", "hashtagtwo"}


### PR DESCRIPTION
After looking into the Mastodon code I found out that it has a special treatment to identify hashtags and skip them while looking for candidates for the preview card.

To mark a link as hashtag it checks for the `rel="tag"` attribute in the links.

https://github.com/mastodon/mastodon/blob/main/app/services/fetch_link_card_service.rb#L97

Notice that once Mastodon ingests it, the `rel="tag"` gets removed from the link and the link receives a `class="status-link"` at the interface.