### PR TITLE
Fix nameserver substitution for IPv6 resolvers

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Set up cache size and nameserver subs
+# Nameservers are taken from /etc/resolv.conf - if the IP contains ":", it's IPv6 and must be enclosed in [] for nginx
 CACHE_SIZE="${TAKAHE_NGINX_CACHE_SIZE:-1g}"
-NAMESERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}' | tr '\n' ' '`
+NAMESERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print ($2 ~ ":") ? "["$2"]" : $2}' | tr '\n' ' '`
 if [ -z "$NAMESERVER" ]; then
     NAMESERVER="9.9.9.9 149.112.112.112"
 fi


### PR DESCRIPTION
It seems, the 0.8 release broke deployments on fly.io as the nginx restarts fails with
> nginx: [emerg] invalid port in resolver "fdaa::3" in /etc/nginx/conf.d/default.conf:77

Apparently, fly.io is using IPv6 nameservers internally and if I understand https://nginx.org/en/docs/http/ngx_http_core_module.html#resolver correctly, IPv6 addresses need to be enclosed in `[]` in the `resolver` line in the nginx config file (to differentiate them from port specifications).