### PR TITLE
Show profile icon image on the image viewer

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1187,6 +1187,7 @@ h1.identity .icon {
     height: 80px;
     float: left;
     margin: 0 20px 0 0;
+    cursor: pointer;
 }
 
 h1.identity .emoji {

--- a/templates/identity/view.html
+++ b/templates/identity/view.html
@@ -21,7 +21,14 @@
                 <img src="{{ identity.local_image_url.relative }}" class="banner">
             {% endif %}
 
-            <img src="{{ identity.local_icon_url.relative }}" class="icon">
+            <span
+                _="on click halt the event then call imageviewer.show(me)"
+            >
+                <img src="{{ identity.local_icon_url.relative }}" class="icon"
+                    data-original-url="{{ identity.local_icon_url.relative }}"
+                    alt="Profile image for {{ identity.name }}"
+                >
+            </span>
 
             {% if request.identity %}{% include "identity/_view_menu.html" %}{% endif %}
 


### PR DESCRIPTION
resolves #519

This allows viewing the profile icon image on the image viewer. I was able to reuse the existing image viewer code.

<img width="691" alt="Screenshot 2023-02-22 at 18 42 55" src="https://user-images.githubusercontent.com/1425259/220585022-9bc3c44e-f34d-4ef7-ba57-a6179d0f826b.png">
<img width="663" alt="Screenshot 2023-02-22 at 18 50 46" src="https://user-images.githubusercontent.com/1425259/220585041-d7c684c4-1764-4fdf-a672-9ba22bf019c4.png">
