### PR TITLE
Put no ALT badge on attached images

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1506,6 +1506,7 @@ form .post {
 }
 
 .post .attachments a {
+    position: relative;
     display: block;
     width: 100%;
 }
@@ -1516,6 +1517,18 @@ form .post {
     object-fit: cover;
     object-position: center;
     max-height: 400px;
+}
+
+.post .attachments .badge {
+    position: absolute;
+    bottom: 6px;
+    left: 6px;
+    padding: 0 4px;
+    border-radius: 4px;
+    font-size: 14px;
+    font-weight: bold;
+    color: var(--color-text-in-highlight);
+    background: rgb(0 0 0 / 60%);
 }
 
 .post .attachments video {

--- a/templates/activities/_post.html
+++ b/templates/activities/_post.html
@@ -46,6 +46,9 @@
                         <a href="{{ attachment.full_url.relative }}" class="image" target="_blank"
                             _="on click halt the event then call imageviewer.show(me)">
                             <img src="{{ attachment.thumbnail_url.relative }}" title="{{ attachment.name }}" alt="{{ attachment.name|default:'(no description)' }}" loading="lazy" data-original-url="{{ attachment.full_url.relative }}">
+                            {% if not attachment.name %}
+                                <div class="badge"><i class="fas fa-times"></i> ALT</div>
+                            {% endif %}
                         </a>
                     {% elif attachment.is_video %}
                         <a href="{{ attachment.full_url.relative }}" class="video">

--- a/templates/activities/_post.html
+++ b/templates/activities/_post.html
@@ -46,8 +46,8 @@
                         <a href="{{ attachment.full_url.relative }}" class="image" target="_blank"
                             _="on click halt the event then call imageviewer.show(me)">
                             <img src="{{ attachment.thumbnail_url.relative }}" title="{{ attachment.name }}" alt="{{ attachment.name|default:'(no description)' }}" loading="lazy" data-original-url="{{ attachment.full_url.relative }}">
-                            {% if not attachment.name %}
-                                <div class="badge"><i class="fas fa-times"></i> ALT</div>
+                            {% if attachment.name %}
+                                <div class="badge">ALT</div>
                             {% endif %}
                         </a>
                     {% elif attachment.is_video %}


### PR DESCRIPTION
resolves #336

This PR adds a "No ALT" (x ALT) badge on the left bottom place of an image if it has no description.

**Example:**
<img width="556" alt="Screenshot 2023-01-19 at 13 47 02" src="https://user-images.githubusercontent.com/1425259/220588848-93ff7667-13c3-4788-98d0-275d55a8033f.png">

But I think there are other options too:

<img width="561" alt="Screenshot 2023-01-19 at 13 46 43" src="https://user-images.githubusercontent.com/1425259/220588821-064d91fa-0724-47ba-a0ca-4503058fe8f4.png">
<img width="563" alt="Screenshot 2023-01-19 at 13 48 34" src="https://user-images.githubusercontent.com/1425259/220588835-488a6050-438f-4470-bc8b-5c76dcff56b6.png">
<img width="556" alt="Screenshot 2023-01-19 at 13 47 30" src="https://user-images.githubusercontent.com/1425259/220588842-99b22740-e61b-4e46-9d92-bd9a83bb6762.png">

I choose the current one because it prevents the actual image from being hidden (some people don't like that and ask some clients to add an option to hide the ALT badge) as well as it can encourage people to write a description for better accessibility.
