### PR TITLE
Fix not fetching images properlly when url is redirected

### DIFF
--- a/core/files.py
+++ b/core/files.py
@@ -71,7 +71,9 @@ async def get_remote_file(
     }
 
     async with httpx.AsyncClient(headers=headers) as client:
-        async with client.stream("GET", url, timeout=timeout) as stream:
+        async with client.stream(
+            "GET", url, timeout=timeout, follow_redirects=True
+        ) as stream:
             allow_download = max_size is None
             if max_size:
                 try:


### PR DESCRIPTION
When testing the parsing of the broken emojis found out that the ones that are being redirected were not rendering because the URL was being redirected but httpx was not following it.