### PR TITLE
Accept hs2019 in signatures (Fixes part of federation with GoToSocial)

### DIFF
--- a/core/signatures.py
+++ b/core/signatures.py
@@ -162,7 +162,10 @@ class HttpSignature:
         # Reject unknown algorithms
         # hs2019 is used by some libraries to obfuscate the real algorithm per the spec
         # https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12
-        if signature_details["algorithm"] != "rsa-sha256" and signature_details["algorithm"] != "hs2019":
+        if (
+            signature_details["algorithm"] != "rsa-sha256"
+            and signature_details["algorithm"] != "hs2019"
+        ):
             raise VerificationFormatError("Unknown signature algorithm")
         # Create the signature payload
         headers_string = cls.headers_from_request(request, signature_details["headers"])

--- a/core/signatures.py
+++ b/core/signatures.py
@@ -160,6 +160,8 @@ class HttpSignature:
             raise VerificationFormatError("No signature header present")
         signature_details = cls.parse_signature(request.headers["signature"])
         # Reject unknown algorithms
+        # hs2019 is used by some libraries to obfuscate the real algorithm per the spec
+        # https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12
         if signature_details["algorithm"] != "rsa-sha256" and signature_details["algorithm"] != "hs2019":
             raise VerificationFormatError("Unknown signature algorithm")
         # Create the signature payload

--- a/core/signatures.py
+++ b/core/signatures.py
@@ -160,7 +160,7 @@ class HttpSignature:
             raise VerificationFormatError("No signature header present")
         signature_details = cls.parse_signature(request.headers["signature"])
         # Reject unknown algorithms
-        if signature_details["algorithm"] != "rsa-sha256":
+        if signature_details["algorithm"] != "rsa-sha256" and signature_details["algorithm"] != "hs2019":
             raise VerificationFormatError("Unknown signature algorithm")
         # Create the signature payload
         headers_string = cls.headers_from_request(request, signature_details["headers"])


### PR DESCRIPTION
Reference: https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12 It is recommended to list "hs2019" instead of the actual signature algorith in order to obscure attack vectors.

Some fediverse servers, including the library used by GoToSocial, do this, and rejecting those signatures blocked incoming requests to the inbox.

The validation being used here can still process the signature even with the algorithm field labeled this way, so allowing it fixes this part of the incompatibility described in #528 , namely that a message from a GoToSocial user mentioning a Takahe user doesn't federate to the Takahe instance.

