### PR TITLE
Allow to set default reply visibility

### DIFF
--- a/activities/views/compose.py
+++ b/activities/views/compose.py
@@ -123,7 +123,9 @@ class Compose(FormView):
             if self.reply_to:
                 initial["reply_to"] = self.reply_to.pk
                 if self.reply_to.visibility == Post.Visibilities.public:
-                    initial["visibility"] = Post.Visibilities.unlisted
+                    initial[
+                        "visibility"
+                    ] = self.request.identity.config_identity.default_reply_visibility
                 else:
                     initial["visibility"] = self.reply_to.visibility
                 initial["content_warning"] = self.reply_to.summary

--- a/core/models/config.py
+++ b/core/models/config.py
@@ -246,6 +246,7 @@ class Config(models.Model):
 
         toot_mode: bool = False
         default_post_visibility: int = 0  # Post.Visibilities.public
+        default_reply_visibility: int = 1  # Post.Visibilities.unlisted
         visible_follows: bool = True
         light_theme: bool = False
 

--- a/users/views/settings/interface.py
+++ b/users/views/settings/interface.py
@@ -16,6 +16,11 @@ class InterfacePage(SettingsPage):
             "help_text": "Visibility to use as default for new posts.",
             "choices": Post.Visibilities.choices,
         },
+        "default_reply_visibility": {
+            "title": "Default Reply Visibility",
+            "help_text": "Visibility to use as default for replies.",
+            "choices": Post.Visibilities.choices,
+        },
         "visible_reaction_counts": {
             "title": "Show Boost and Like Counts",
             "help_text": "Disable to hide the number of Likes and Boosts on a 'Post'",
@@ -40,7 +45,7 @@ class InterfacePage(SettingsPage):
     }
 
     layout = {
-        "Posting": ["toot_mode", "default_post_visibility"],
+        "Posting": ["toot_mode", "default_post_visibility", "default_reply_visibility"],
         "Wellness": ["infinite_scroll", "visible_reaction_counts", "expand_linked_cws"],
         "Appearance": ["light_theme", "custom_css"],
     }


### PR DESCRIPTION
Fixes #256 

Wasn't sure if it's worth filtering the post visibility changes on the settings page to only allow to switch between public and unlisted. I guess the only one that doesn't make much sense is local only when trying to reply to a remote status.