### PR TITLE
Initial support for IceCubes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,9 @@
 .pre-commit-config.yaml
 .venv
 /fly.*
+/static-collected
+/takahe/local_settings.py
+__pycache__/
 media
 notes.md
 venv

--- a/api/views/apps.py
+++ b/api/views/apps.py
@@ -1,28 +1,27 @@
 import secrets
 
-from hatchway import Schema, api_view
+from hatchway import QueryOrBody, api_view
 
 from .. import schemas
 from ..models import Application
 
 
-class CreateApplicationSchema(Schema):
-    client_name: str
-    redirect_uris: str
-    scopes: None | str = None
-    website: None | str = None
-
-
 @api_view.post
-def add_app(request, details: CreateApplicationSchema) -> schemas.Application:
+def add_app(
+    request,
+    client_name: QueryOrBody[str],
+    redirect_uris: QueryOrBody[str],
+    scopes: QueryOrBody[None | str] = None,
+    website: QueryOrBody[None | str] = None,
+) -> schemas.Application:
     client_id = "tk-" + secrets.token_urlsafe(16)
     client_secret = secrets.token_urlsafe(40)
     application = Application.objects.create(
-        name=details.client_name,
-        website=details.website,
+        name=client_name,
+        website=website,
         client_id=client_id,
         client_secret=client_secret,
-        redirect_uris=details.redirect_uris,
-        scopes=details.scopes or "read",
+        redirect_uris=redirect_uris,
+        scopes=scopes or "read",
     )
     return schemas.Application.from_orm(application)

--- a/api/views/instance.py
+++ b/api/views/instance.py
@@ -47,6 +47,12 @@ def instance_info_v1(request):
                 "image_size_limit": (1024**2) * 10,
                 "image_matrix_limit": 2000 * 2000,
             },
+            "polls": {
+                "max_options": 4,
+                "max_characters_per_option": 50,
+                "min_expiration": 300,
+                "max_expiration": 2629746,
+            },
         },
         "contact_account": None,
         "rules": [],

--- a/tests/api/test_apps.py
+++ b/tests/api/test_apps.py
@@ -4,10 +4,8 @@ import pytest
 @pytest.mark.django_db
 def test_create(api_client):
     """
-    Tests creating an app
+    Tests creating an app with mixed query/body params (some clients do this)
     """
-    response = api_client.post(
-        "/api/v1/apps", {"client_name": "test", "redirect_uris": ""}
-    )
+    response = api_client.post("/api/v1/apps?client_name=test", {"redirect_uris": ""})
     assert response.status_code == 200
     assert response.json()["name"] == "test"


### PR DESCRIPTION
IceCubes (an open source iOS client) is using the v1/instance API and expecting a "polls" configuration. It also `POST`s to `v1/apps` using query parameters:

> 127.0.0.1 - - [09/Mar/2023:15:39:59 +0000] "POST /api/v1/apps?client_name=IceCubesApp&redirect_uris=icecubesapp://&scopes=read%20write%20follow%20push&website=https://github.com/Dimillian/IceCubesApp HTTP/1.1" 500 3309 "-" "IceCubesApp/1735 CFNetwork/1404.0.5 Darwin/22.3.0"

This is likely a bug on their end? But in the interest of wider client support, it was easy to accept both. Not sure your feelings on how strict the interpretation of the API should be. I've tested this on my instance (https://quiet.social) - there are other issues, but this is enough to get the basics working.