### PR TITLE
Add `mention` and `hashtag` classes to hashtag anchors

### DIFF
--- a/core/html.py
+++ b/core/html.py
@@ -205,7 +205,7 @@ class FediverseHtmlParser(HTMLParser):
         hashtag = hashtag.lstrip("#")
         self.hashtags.add(hashtag.lower())
         if self.uri_domain:
-            return f'<a href="https://{self.uri_domain}/tags/{hashtag.lower()}/" rel="tag">#{hashtag}</a>'
+            return f'<a href="https://{self.uri_domain}/tags/{hashtag.lower()}/" class="mention hashtag" rel="tag">#{hashtag}</a>'
         else:
             return f'<a href="/tags/{hashtag.lower()}/" rel="tag">#{hashtag}</a>'
 


### PR DESCRIPTION
Related to #541 

* This fixes hashtag detection in Ivory and Mona.
* Elk doesn't work yet because the regex fails to match due to the trailing slash of the URL
* Semaphore doesn't use a regex, but checks the suffix of the URL, so fails as well due to the trailing slash