### PR TITLE
Always return voters_count

### DIFF
--- a/activities/models/post_types.py
+++ b/activities/models/post_types.py
@@ -58,7 +58,7 @@ class QuestionData(BasePostDataType):
             "expired": False,
             "multiple": multiple,
             "votes_count": 0,
-            "voters_count": self.voter_count if multiple else None,
+            "voters_count": self.voter_count,
             "voted": False,
             "own_votes": [],
             "options": [],

--- a/tests/api/test_statuses.py
+++ b/tests/api/test_statuses.py
@@ -131,7 +131,7 @@ def test_question_format(api_client, remote_identity):
         "expired": True,
         "multiple": False,
         "votes_count": 30,
-        "voters_count": None,
+        "voters_count": 30,
         "voted": False,
         "own_votes": [],
         "options": [


### PR DESCRIPTION
Even though mastodon says in doc that `voters_count` can be null, it returns the `voters_count` even when it's not a multiple choice case, and some clients like the main mastodon and megalodon (that uses the same codebase) relies on it to display the totals.