### PR TITLE
handle posts with only contentMap as post instead of interaction

### DIFF
--- a/tests/activities/models/test_post.py
+++ b/tests/activities/models/test_post.py
@@ -430,6 +430,30 @@ def test_inbound_posts(
     stator.run_single_cycle_sync()
     assert not Post.objects.filter(object_uri="https://remote.test/test-post").exists()
 
+    # Create an inbound new post message with only contentMap
+    message = {
+        "id": "test",
+        "type": "Create",
+        "actor": remote_identity.actor_uri,
+        "object": {
+            "id": "https://remote.test/test-map-only",
+            "type": "Note",
+            "published": "2022-11-13T23:20:16Z",
+            "attributedTo": remote_identity.actor_uri,
+            "contentMap": {"und": "post with only content map"},
+        },
+    }
+    InboxMessage.objects.create(message=message)
+
+    # Run stator and ensure that made the post
+    print("prestat")
+    stator.run_single_cycle_sync()
+    print("poststat")
+    post = Post.objects.get(object_uri="https://remote.test/test-map-only")
+    assert post.content == "post with only content map"
+    assert post.published.day == 13
+    assert post.url == "https://remote.test/test-map-only"
+
 
 @pytest.mark.django_db
 def test_post_hashtag_to_ap(identity: Identity, config_system):

--- a/users/models/inbox_message.py
+++ b/users/models/inbox_message.py
@@ -222,4 +222,5 @@ class InboxMessage(StatorModel):
 
     @property
     def message_object_has_content(self):
-        return "content" in self.message.get("object", {})
+        object = self.message.get("object", {})
+        return "content" in object or "contentMap" in object


### PR DESCRIPTION
Fixes #548

Not 100% sure if this is the right solution, or if it has any unintended side-effects. I'm still quite new on understanding the various ActivityPub permutations.

Thinking since once we're trying to create a `Post` we are taking its content from either the `"content"` key or the `"contentMap"` [here](https://github.com/jointakahe/takahe/blob/ea7d5f307cb69e5e9555770223e7a9594a0d8421/activities/models/post.py#L848), that the `InboxMessage` processing should probably follow the same logic.