### PR TITLE
fix /v1/statuses/<id>/favourited_by pagination header error

### DIFF
--- a/api/views/statuses.py
+++ b/api/views/statuses.py
@@ -16,7 +16,7 @@ from activities.models import (
 from activities.services import PostService
 from api import schemas
 from api.decorators import scope_required
-from api.pagination import MastodonPaginator, PaginationResult
+from api.pagination import MastodonPaginator, PaginatingApiResponse, PaginationResult
 from core.models import Config
 
 
@@ -230,10 +230,7 @@ def favourited_by(
         limit=limit,
     )
 
-    headers = {}
-    if pager.results:
-        headers = {"link": pager.link_header(request, ["limit"])}
-    return ApiResponse(
+    return PaginatingApiResponse(
         [
             schemas.Account.from_identity(
                 interaction.identity,
@@ -241,7 +238,11 @@ def favourited_by(
             )
             for interaction in pager.results
         ],
-        headers=headers,
+        request=request,
+        include_params=[
+            "limit",
+            "id",
+        ],
     )
 
 


### PR DESCRIPTION
Getting this stack trace for all `GET /api/v1/statuses/<id>/favourited_by` requests when the status is favourited:

```
ValueError: You must JSONify the results first
  File "django/core/handlers/exception.py", line 56, in inner
    response = get_response(request)
  File "django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "hatchway/view.py", line 302, in __call__
    response = self.view(request, **kwargs)
  File "api/views/statuses.py", line 235, in favourited_by
    headers = {"link": pager.link_header(request, ["limit"])}
  File "api/pagination.py", line 140, in link_header
    f'<{self.next(request, allowed_params)}>; rel="next"',
  File "api/pagination.py", line 115, in next
    raise ValueError("You must JSONify the results first")
```

This was the only endpoint which still used the `ApiResponse` and set the link header itself without using `PaginatingApiResponse`. I did a quick pagination test locally and it seems to still work.