### PR TITLE
set post attachment type correctly for videos

### DIFF
--- a/activities/models/post_attachment.py
+++ b/activities/models/post_attachment.py
@@ -131,9 +131,14 @@ class PostAttachment(StatorModel):
     ### Mastodon Client API ###
 
     def to_mastodon_json(self):
+        type_ = "unknown"
+        if self.is_image():
+            type_ = "image"
+        elif self.is_video():
+            type_ = "video"
         value = {
             "id": self.pk,
-            "type": "image" if self.is_image() else "unknown",
+            "type": type_,
             "url": self.full_url().absolute,
             "preview_url": self.thumbnail_url().absolute,
             "remote_url": None,


### PR DESCRIPTION
it's still unclear to me how Mastodon detects gifs, as the ActivityPub representation for a post with a gif looks identical to one with a video. Takahē imports these post attachments as videos at the moment, so these would also be rendered as videos in the meantime.

update: Mastodon detects gifs by transcoding videos and checking if there is an audio codec ([src](https://github.com/mastodon/mastodon/blob/2b113764117c9ab98875141bcf1758ba8be58173/lib/paperclip/transcoder.rb#L113)), not something that Takahē would be able to do at this point in time.