### PR TITLE
Improve hashtag case handling and implement /api/v1/tags/<hashtag> endpoint

### DIFF
--- a/activities/models/hashtag.py
+++ b/activities/models/hashtag.py
@@ -168,14 +168,14 @@ class Hashtag(StatorModel):
                 results[date(year, month, day)] = val
         return dict(sorted(results.items(), reverse=True)[:num])
 
-    def to_mastodon_json(self, followed: bool | None = None):
+    def to_mastodon_json(self, following: bool | None = None):
         value = {
             "name": self.hashtag,
             "url": self.urls.view.full(),  # type: ignore
             "history": [],
         }
 
-        if followed is not None:
-            value["followed"] = followed
+        if following is not None:
+            value["following"] = following
 
         return value

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -276,15 +276,15 @@ class Tag(Schema):
     name: str
     url: str
     history: dict
-    followed: bool | None
+    following: bool | None
 
     @classmethod
     def from_hashtag(
         cls,
         hashtag: activities_models.Hashtag,
-        followed: bool | None = None,
+        following: bool | None = None,
     ) -> "Tag":
-        return cls(**hashtag.to_mastodon_json(followed=followed))
+        return cls(**hashtag.to_mastodon_json(following=following))
 
 
 class FollowedTag(Tag):
@@ -295,7 +295,7 @@ class FollowedTag(Tag):
         cls,
         follow: users_models.HashtagFollow,
     ) -> "FollowedTag":
-        return cls(id=follow.id, **follow.hashtag.to_mastodon_json(followed=True))
+        return cls(id=follow.id, **follow.hashtag.to_mastodon_json(following=True))
 
     @classmethod
     def map_from_follows(

--- a/api/urls.py
+++ b/api/urls.py
@@ -96,6 +96,7 @@ urlpatterns = [
     path("v1/statuses/<id>/unbookmark", statuses.unbookmark_status),
     # Tags
     path("v1/followed_tags", tags.followed_tags),
+    path("v1/tags/<hashtag>", tags.hashtag),
     path("v1/tags/<id>/follow", tags.follow),
     path("v1/tags/<id>/unfollow", tags.unfollow),
     # Timelines

--- a/api/views/tags.py
+++ b/api/views/tags.py
@@ -58,7 +58,7 @@ def follow(
 ) -> schemas.Tag:
     hashtag = get_object_or_404(
         Hashtag,
-        pk=id,
+        pk=id.lower(),
     )
     request.identity.hashtag_follows.get_or_create(hashtag=hashtag)
     return schemas.Tag.from_hashtag(
@@ -75,7 +75,7 @@ def unfollow(
 ) -> schemas.Tag:
     hashtag = get_object_or_404(
         Hashtag,
-        pk=id,
+        pk=id.lower(),
     )
     request.identity.hashtag_follows.filter(hashtag=hashtag).delete()
     return schemas.Tag.from_hashtag(

--- a/api/views/tags.py
+++ b/api/views/tags.py
@@ -9,6 +9,22 @@ from api.pagination import MastodonPaginator, PaginatingApiResponse, PaginationR
 from users.models import HashtagFollow
 
 
+@api_view.get
+def hashtag(request: HttpRequest, hashtag: str) -> schemas.Tag:
+    tag = get_object_or_404(
+        Hashtag,
+        pk=hashtag.lower(),
+    )
+    followed = None
+    if request.identity:
+        followed = tag.followers.filter(identity=request.identity).exists()
+
+    return schemas.Tag.from_hashtag(
+        tag,
+        followed=followed,
+    )
+
+
 @scope_required("read:follows")
 @api_view.get
 def followed_tags(

--- a/api/views/tags.py
+++ b/api/views/tags.py
@@ -15,13 +15,13 @@ def hashtag(request: HttpRequest, hashtag: str) -> schemas.Tag:
         Hashtag,
         pk=hashtag.lower(),
     )
-    followed = None
+    following = None
     if request.identity:
-        followed = tag.followers.filter(identity=request.identity).exists()
+        following = tag.followers.filter(identity=request.identity).exists()
 
     return schemas.Tag.from_hashtag(
         tag,
-        followed=followed,
+        following=following,
     )
 
 
@@ -63,7 +63,7 @@ def follow(
     request.identity.hashtag_follows.get_or_create(hashtag=hashtag)
     return schemas.Tag.from_hashtag(
         hashtag,
-        followed=True,
+        following=True,
     )
 
 
@@ -80,5 +80,5 @@ def unfollow(
     request.identity.hashtag_follows.filter(hashtag=hashtag).delete()
     return schemas.Tag.from_hashtag(
         hashtag,
-        followed=False,
+        following=False,
     )

--- a/api/views/timelines.py
+++ b/api/views/timelines.py
@@ -101,7 +101,7 @@ def hashtag(
 ) -> ApiResponse[list[schemas.Status]]:
     if limit > 40:
         limit = 40
-    queryset = TimelineService(request.identity).hashtag(hashtag)
+    queryset = TimelineService(request.identity).hashtag(hashtag.lower())
     if local:
         queryset = queryset.filter(local=True)
     if only_media:


### PR DESCRIPTION
When clicking on a hashtag from a post, Ivory doesn't use the `tags` urls, but seems to be constructing the URL by itself. This results in empty hashtag timelines if the tag contains uppercase letters, because we [lowercase hashtags when storing](https://github.com/jointakahe/takahe/blob/216915ddb8d1dc88363ced775f6e154c8f7978a1/core/html.py#L210) them.

Implementing the `/api/v1/tags/<hashtag>` endpoint will also allow Ivory (or other clients) users to follow hashtags, and the follow/unfollow endpoints also lowercase the hashtag now.

i.e. for this [post](https://social.chdorner.com/api/v1/statuses/166888674863510336) Ivory calls `/api/v1/timelines/tag/OER23?limit=40`

Following/unfollowing from the tag timeline works in Mona as well. IceCubes is having some issues because the it calls `/api/v1/tags/<hashtag>/` (with a trailing slash) which currently results in a 404.