### PR TITLE
Support editing media description when editing statuses

### DIFF
--- a/activities/models/post.py
+++ b/activities/models/post.py
@@ -518,6 +518,7 @@ class Post(StatorModel):
         sensitive: bool | None = None,
         visibility: int = Visibilities.public,
         attachments: list | None = None,
+        attachment_attributes: list | None = None,
     ):
         with transaction.atomic():
             # Strip all HTML and apply linebreaks filter
@@ -532,6 +533,15 @@ class Post(StatorModel):
             self.emojis.set(Emoji.emojis_from_content(content, None))
             self.attachments.set(attachments or [])
             self.save()
+
+            for attrs in attachment_attributes or []:
+                attachment = next(
+                    (a for a in attachments or [] if str(a.id) == attrs.id), None
+                )
+                if attachment is None:
+                    continue
+                attachment.name = attrs.description
+                attachment.save()
 
     @classmethod
     def mentions_from_content(cls, content, author) -> set[Identity]:

--- a/api/views/statuses.py
+++ b/api/views/statuses.py
@@ -50,12 +50,18 @@ class PostStatusSchema(Schema):
     poll: PostPollSchema | None = None
 
 
+class MediaAttributesSchema(Schema):
+    id: str
+    description: str
+
+
 class EditStatusSchema(Schema):
     status: str
     sensitive: bool = False
     spoiler_text: str | None = None
     language: str | None = None
     media_ids: list[str] = []
+    media_attributes: list[MediaAttributesSchema] = []
 
 
 def post_for_id(request: HttpRequest, id: str) -> Post:
@@ -134,6 +140,7 @@ def edit_status(request, id: str, details: EditStatusSchema) -> schemas.Status:
         summary=details.spoiler_text,
         sensitive=details.sensitive,
         attachments=attachments,
+        attachment_attributes=details.media_attributes,
     )
     return schemas.Status.from_post(post)
 


### PR DESCRIPTION
The `media_attributes` key has not made it into the docs yet, but the functionality has been merged in mastodon/mastodon#20878.

At least Ivory is using this key, and it's only sent when there are changes, so we preserve alt texts when the key is not in the request.
Mona on the other hand seems to not use this, but calls `POST /api/v2/media` before editing the post.