### PR TITLE
Sentry/S3 storage/Google storage should be optional

### DIFF
--- a/core/uploads.py
+++ b/core/uploads.py
@@ -7,7 +7,10 @@ try:
     from storages.backends.gcloud import GoogleCloudStorage
 except ImportError:
     GoogleCloudStorage = None
-from storages.backends.s3boto3 import S3Boto3Storage
+try:
+    from storages.backends.s3boto3 import S3Boto3Storage
+except ImportError:
+    S3Boto3Storage = None
 
 if TYPE_CHECKING:
     from activities.models import Emoji
@@ -37,17 +40,18 @@ def upload_emoji_namer(prefix, instance: "Emoji", filename):
     return f"{prefix}/{domain}/{instance.shortcode}{old_extension}"
 
 
-class TakaheS3Storage(S3Boto3Storage):
-    """
-    Custom override backend that makes webp files store correctly
-    """
+if S3Boto3Storage:
+    class TakaheS3Storage(S3Boto3Storage):
+        """
+        Custom override backend that makes webp files store correctly
+        """
 
-    def get_object_parameters(self, name: str):
-        params = self.object_parameters.copy()
-        if name.endswith(".webp"):
-            params["ContentDisposition"] = "inline"
-            params["ContentType"] = "image/webp"
-        return params
+        def get_object_parameters(self, name: str):
+            params = self.object_parameters.copy()
+            if name.endswith(".webp"):
+                params["ContentDisposition"] = "inline"
+                params["ContentType"] = "image/webp"
+            return params
 
 
 if GoogleCloudStorage:

--- a/core/uploads.py
+++ b/core/uploads.py
@@ -3,7 +3,10 @@ import secrets
 from typing import TYPE_CHECKING
 
 from django.utils import timezone
-from storages.backends.gcloud import GoogleCloudStorage
+try:
+    from storages.backends.gcloud import GoogleCloudStorage
+except ImportError:
+    GoogleCloudStorage = None
 from storages.backends.s3boto3 import S3Boto3Storage
 
 if TYPE_CHECKING:
@@ -47,14 +50,15 @@ class TakaheS3Storage(S3Boto3Storage):
         return params
 
 
-class TakaheGoogleCloudStorage(GoogleCloudStorage):
-    """
-    Custom override backend that makes webp files store correctly
-    """
+if GoogleCloudStorage:
+    class TakaheGoogleCloudStorage(GoogleCloudStorage):
+        """
+        Custom override backend that makes webp files store correctly
+        """
 
-    def get_object_parameters(self, name: str):
-        params = self.object_parameters.copy()
-        if name.endswith(".webp"):
-            params["content_disposition"] = "inline"
-            params["content_type"] = "image/webp"
-        return params
+        def get_object_parameters(self, name: str):
+            params = self.object_parameters.copy()
+            if name.endswith(".webp"):
+                params["content_disposition"] = "inline"
+                params["content_type"] = "image/webp"
+            return params

--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -8,9 +8,7 @@ from typing import Literal
 import dj_database_url
 import django_cache_url
 import httpx
-import sentry_sdk
 from pydantic import AnyUrl, BaseSettings, EmailStr, Field, validator
-from sentry_sdk.integrations.django import DjangoIntegration
 
 from takahe import __version__
 
@@ -347,6 +345,8 @@ if SETUP.USE_PROXY_HEADERS:
 
 
 if SETUP.SENTRY_DSN:
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.integrations.httpx import HttpxIntegration
 
     sentry_experiments = {}


### PR DESCRIPTION
I don't want to use S3/Google storage nor Sentry. I don't want install those dependencies.

I this case Takahe cannot start.