### PR TITLE
Fix post attachment author check on editing

### DIFF
--- a/api/views/media.py
+++ b/api/views/media.py
@@ -72,7 +72,10 @@ def update_media(
     focus: QueryOrBody[str] = "0,0",
 ) -> schemas.MediaAttachment:
     attachment = get_object_or_404(PostAttachment, pk=id)
-    if attachment.post.author != request.identity:
+    if attachment.post:
+        if attachment.post.author != request.identity:
+            raise ApiError(401, "Not the author of this attachment")
+    elif attachment.author != request.identity:
         raise ApiError(401, "Not the author of this attachment")
     attachment.name = description or None
     attachment.save()


### PR DESCRIPTION
Found this when adding alt text while composing a post in Elk, it sends a request to `PUT /api/v1/media/<id>` when the post attachment doesn't have a post yet.