### PR TITLE
fix order of next/prev header links

### DIFF
--- a/api/pagination.py
+++ b/api/pagination.py
@@ -76,8 +76,8 @@ class PaginatingApiResponse(ApiResponse[list[TI]]):
         parts = [
             entry
             for entry in [
-                self.get_part(0, "min_id", "prev"),
                 self.get_part(-1, "max_id", "next"),
+                self.get_part(0, "min_id", "prev"),
             ]
             if entry
         ]


### PR DESCRIPTION
Related to #562, should be the last change to make pagination work in Elk. Fixed in neet/masto.js#899, but not yet released either in masto.js or in Elk.