### PR TITLE
fix: bug in middleware when domain config is None

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -18,7 +18,7 @@ from core.models import Config
 def homepage(request):
     if request.user.is_authenticated:
         return Home.as_view()(request)
-    elif request.domain.config_domain.single_user:
+    elif request.domain and request.domain.config_domain.single_user:
         return redirect(f"/@{request.domain.config_domain.single_user}/")
     else:
         return About.as_view()(request)


### PR DESCRIPTION
Fixes a bug in the homepage render when no domain config exists (like in a fresh install)