### PR TITLE
Ignore unknown create/update types

### DIFF
--- a/users/models/inbox_message.py
+++ b/users/models/inbox_message.py
@@ -42,10 +42,6 @@ class InboxMessageStates(StateGraph):
                     case unknown:
                         if unknown in Post.Types.names:
                             await sync_to_async(Post.handle_create_ap)(instance.message)
-                        else:
-                            raise ValueError(
-                                f"Cannot handle activity of type create.{unknown}"
-                            )
             case "update":
                 match instance.message_object_type:
                     case "note":
@@ -65,10 +61,6 @@ class InboxMessageStates(StateGraph):
                     case unknown:
                         if unknown in Post.Types.names:
                             await sync_to_async(Post.handle_update_ap)(instance.message)
-                        else:
-                            raise ValueError(
-                                f"Cannot handle activity of type update.{unknown}"
-                            )
             case "accept":
                 match instance.message_object_type:
                     case "follow":


### PR DESCRIPTION
I'm following my BookWyrm account and whenever it is federating out create or update activities, I get quite a few of these errors (filling up my free Sentry quota 😅) and inbox messages being retried until they are finally dropped. One example is `ValueError: Cannot handle activity of type update.generatednote`, `GeneratedNote` being a `BookWyrm` type.

I checked how Mastodon handles this, and they seem to be just dropping any types that they don't natively support, or support as converted types:
* Create: https://github.com/mastodon/mastodon/blob/ac41a9712ecebdbc991fd290c7ce3236b26bc9cf/app/lib/activitypub/activity/create.rb#L48
* Update: https://github.com/mastodon/mastodon/blob/ac41a9712ecebdbc991fd290c7ce3236b26bc9cf/app/lib/activitypub/activity/update.rb#L7C9-L13