### PR TITLE
Migrate to new staticfiles storage setting

### DIFF
--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -303,7 +303,11 @@ STATICFILES_FINDERS = [
 
 STATICFILES_DIRS = [BASE_DIR / "static"]
 
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+    },
+}
 
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,9 +58,11 @@ kwIDAQAB
 
 @pytest.fixture(autouse=True)
 def _test_settings(settings):
-    settings.STATICFILES_STORAGE = (
-        "django.contrib.staticfiles.storage.StaticFilesStorage"
-    )
+    settings.STORAGES = {
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+        },
+    }
     settings.SETUP.MAIN_DOMAIN = "example.com"
     settings.MAIN_DOMAIN = "example.com"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,8 @@ kwIDAQAB
 
 @pytest.fixture(autouse=True)
 def _test_settings(settings):
+    # We use `StaticFilesStorage` instead of `ManifestStaticFilesStorage` in tests
+    # since want stable filenames (`css/styles.css`) instead of hashed (`css/styles.55e7cbb9ba48.css`)
     settings.STORAGES = {
         "staticfiles": {
             "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ kwIDAQAB
 def _test_settings(settings):
     settings.STORAGES = {
         "staticfiles": {
-            "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
         },
     }
     settings.SETUP.MAIN_DOMAIN = "example.com"


### PR DESCRIPTION
Migrates to the new settings key for staticfiles storage.

`STATICFILES_STORAGE` was deprecreated in django 4.2, and the docs suggest moving to the `STORAGES` setting.

Docs: 
* https://django.readthedocs.io/en/stable/ref/settings.html#staticfiles-storage
* https://django.readthedocs.io/en/stable/ref/settings.html#storages