### PR TITLE
Add link to other Mastodon apps

### DIFF
--- a/templates/activities/home.html
+++ b/templates/activities/home.html
@@ -29,7 +29,9 @@
         <p>
             To see your timelines, compose and edit messages, and follow people,
             you will need to use a Mastodon-compatible app. Our favourites
-            are listed below, but there's lots more options out there!
+            are listed below, but there's
+            <a href="https://joinmastodon.org/apps">lots more options</a>
+            out there!
         </p>
         <div class="flex-icons">
             <a href="https://elk.zone/">


### PR DESCRIPTION
Hi, how about adding the link to https://joinmastodon.org/apps to help those who may like other applications to find apps? 

<img width="869" alt="Screenshot 2023-05-06 at 20 05 32" src="https://user-images.githubusercontent.com/1425259/236620581-b6d518cb-de09-4471-b3f9-a91b182ef960.png">

I'm personally using these three applications on each platform and I think these are good choices. 🙂 