### PR TITLE
Prevent Cloudflare from treating handles as emails

### DIFF
--- a/templates/activities/home.html
+++ b/templates/activities/home.html
@@ -12,7 +12,9 @@
                 <img src="{{ identity.local_icon_url.relative }}">
                 <span class="handle">
                     {{ identity.html_name_or_handle }}
+                    <!--email_off-->
                     <small>@{{ identity.handle }}</small>
+                    <!--/email_off-->
                 </span>
                 <button class="right secondary" _="on click go to url {{ identity.urls.view }} then halt">View</button>
                 <button class="right secondary" _="on click go to url {{ identity.urls.settings }} then halt">Settings</button>

--- a/templates/admin/identities.html
+++ b/templates/admin/identities.html
@@ -35,7 +35,9 @@
                 <td class="name">
                     <a href="{{ identity.urls.admin_edit }}" class="overlay"></a>
                     {{ identity.html_name_or_handle }}
+                    <!--email_off-->
                     <small>@{{ identity.handle }}</small>
+                    <!--/email_off-->
                 </td>
                 <td>
                     {% if identity.restriction == 1 %}

--- a/templates/admin/identity_edit.html
+++ b/templates/admin/identity_edit.html
@@ -3,7 +3,12 @@
 {% block subtitle %}{{ identity.name_or_handle }}{% endblock %}
 
 {% block settings_content %}
-    <h1>{{ identity.html_name_or_handle }} <small>{{ identity.handle }}</small></h1>
+    <h1>
+        {{ identity.html_name_or_handle }} 
+        <!--email_off-->
+        <small>@{{ identity.handle }}</small>
+        <!--/email_off-->
+    </h1>
     <form action="." method="POST">
         {% csrf_token %}
         <fieldset>

--- a/templates/identity/view.html
+++ b/templates/identity/view.html
@@ -43,6 +43,7 @@
         </div>
 
         <h1>{{ identity.html_name_or_handle }}</h1>
+        <!--email_off-->
         <small>
             @{{ identity.handle }}
             <a title="Copy handle"
@@ -56,6 +57,7 @@
                 <i class="fa-solid fa-copy"></i>
             </a>
         </small>
+        <!--/email_off-->
         {% if identity.summary %}
             <div class="bio">
                 {{ identity.safe_summary }}

--- a/templates/settings/delete.html
+++ b/templates/settings/delete.html
@@ -3,7 +3,9 @@
 {% block subtitle %}Token{% endblock %}
 
 {% block settings_content %}
+    <!--email_off-->
     <h1>Deleting {{ identity.handle }}</h1>
+    <!--/email_off-->
     <form action="." method="POST">
         {% csrf_token %}
         <fieldset>
@@ -25,7 +27,9 @@
 
         <div class="buttons">
             <a href="{% url "settings" handle=identity.handle %}" class="button secondary left">Cancel</a>
+            <!--email_off-->
             <button class="danger">Delete {{ identity.handle }}</button>
+            <!--/email_off-->
         </div>
     </form>
 {% endblock %}

--- a/templates/settings/follows.html
+++ b/templates/settings/follows.html
@@ -30,7 +30,9 @@
                 <td class="name">
                     <a href="{{ other_identity.urls.view }}" class="overlay"></a>
                     {{ other_identity.html_name_or_handle }}
+                    <!--email_off-->
                     <small>@{{ other_identity.handle }}</small>
+                    <!--/email_off-->
                 </td>
                 <td class="stat">
                     {% if other_identity.id in outbound_ids %}


### PR DESCRIPTION
A display issue occurs when a Takahē instance is hosted behind a Cloudflare proxy **and** Cloudflare's [Email Address Obfuscation](https://developers.cloudflare.com/support/more-dashboard-apps/cloudflare-scrape-shield/what-is-email-address-obfuscation/) feature is enabled.

Due to the format of handles, Cloudflare treats them as email addresses, and will cause them to display as `@[email protected]`. See below for an example:

![Screenshot from 2023-05-07 12-33-31](https://user-images.githubusercontent.com/21065412/236690882-8229715d-32b4-446d-9b53-fb6b0d36b899.png)

Luckily, Cloudflare provides [a way to force-disable false positives](https://developers.cloudflare.com/support/more-dashboard-apps/cloudflare-scrape-shield/what-is-email-address-obfuscation/#prevent-cloudflare-from-obfuscating-email).

This PR wraps every instance of `@{{identity.handle}}` I could find with the "magic comments" to force-disable email protection, and stop Cloudflare from hiding handles.