### PR TITLE
Fix default storage setting and use new STORAGES

### DIFF
--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -307,6 +307,9 @@ STORAGES = {
     "staticfiles": {
         "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
     },
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
 }
 
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
@@ -404,18 +407,14 @@ if SETUP.MEDIA_BACKEND:
     parsed = urllib.parse.urlparse(SETUP.MEDIA_BACKEND)
     query = urllib.parse.parse_qs(parsed.query)
     if parsed.scheme == "gs":
-        STORAGES["default"] = {
-            "BACKEND": "core.uploads.TakaheGoogleCloudStorage",
-        }
+        STORAGES["default"]["BACKEND"] = "core.uploads.TakaheGoogleCloudStorage"
         GS_BUCKET_NAME = parsed.path.lstrip("/")
         GS_QUERYSTRING_AUTH = False
         if parsed.hostname is not None:
             port = parsed.port or 443
             GS_CUSTOM_ENDPOINT = f"https://{parsed.hostname}:{port}"
     elif parsed.scheme == "s3":
-        STORAGES["default"] = {
-            "BACKEND": "core.uploads.TakaheS3Storage",
-        }
+        STORAGES["default"]["BACKEND"] = "core.uploads.TakaheS3Storage"
         AWS_STORAGE_BUCKET_NAME = parsed.path.lstrip("/")
         AWS_QUERYSTRING_AUTH = False
         AWS_DEFAULT_ACL = SETUP.MEDIA_BACKEND_S3_ACL
@@ -429,9 +428,6 @@ if SETUP.MEDIA_BACKEND:
             media_url_parsed = urllib.parse.urlparse(SETUP.MEDIA_URL)
             AWS_S3_CUSTOM_DOMAIN = media_url_parsed.hostname
     elif parsed.scheme == "local":
-        STORAGES["default"] = {
-            "BACKEND": "django.core.files.storage.FileSystemStorage",
-        }
         if not (MEDIA_ROOT and MEDIA_URL):
             raise ValueError(
                 "You must provide MEDIA_ROOT and MEDIA_URL for a local media backend"

--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -404,14 +404,18 @@ if SETUP.MEDIA_BACKEND:
     parsed = urllib.parse.urlparse(SETUP.MEDIA_BACKEND)
     query = urllib.parse.parse_qs(parsed.query)
     if parsed.scheme == "gs":
-        DEFAULT_FILE_STORAGE = "core.uploads.TakaheGoogleCloudStorage"
+        STORAGES["default"] = {
+            "BACKEND": "core.uploads.TakaheGoogleCloudStorage",
+        }
         GS_BUCKET_NAME = parsed.path.lstrip("/")
         GS_QUERYSTRING_AUTH = False
         if parsed.hostname is not None:
             port = parsed.port or 443
             GS_CUSTOM_ENDPOINT = f"https://{parsed.hostname}:{port}"
     elif parsed.scheme == "s3":
-        DEFAULT_FILE_STORAGE = "core.uploads.TakaheS3Storage"
+        STORAGES["default"] = {
+            "BACKEND": "core.uploads.TakaheS3Storage",
+        }
         AWS_STORAGE_BUCKET_NAME = parsed.path.lstrip("/")
         AWS_QUERYSTRING_AUTH = False
         AWS_DEFAULT_ACL = SETUP.MEDIA_BACKEND_S3_ACL
@@ -425,6 +429,9 @@ if SETUP.MEDIA_BACKEND:
             media_url_parsed = urllib.parse.urlparse(SETUP.MEDIA_URL)
             AWS_S3_CUSTOM_DOMAIN = media_url_parsed.hostname
     elif parsed.scheme == "local":
+        STORAGES["default"] = {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        }
         if not (MEDIA_ROOT and MEDIA_URL):
             raise ValueError(
                 "You must provide MEDIA_ROOT and MEDIA_URL for a local media backend"


### PR DESCRIPTION
I'm still not super well-versed in the Django specifics, but I believe #570 has introduced a problem with how the media storage is configured.
Apparently the use of `DEFAULT_FILE_STORAGE` and `STORAGES` is mutually exclusive and Django refused to boot. Curiously, this only happened on my production setup, not in the development server

I'm using local storage on my instance, so I didn't manually test S3/GCP configs, but looking at the diff I'm assuming that this should be alright.