### PR TITLE
Show posts and boosts on an identity's profile view

### DIFF
--- a/templates/identity/view.html
+++ b/templates/identity/view.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load activity_tags %}
 
 {% block title %}{{ identity }}{% endblock %}
 
@@ -90,8 +91,20 @@
         {% block subcontent %}
 
             <div class="page-content">
-                {% for post in page_obj %}
-                    {% include "activities/_post.html" %}
+                {% for event in page_obj %}
+                    {% if event.type == "post" %}
+                        {% include "activities/_post.html" with post=event.subject_post %}
+                    {% elif event.type == "boost" %}
+                        <div class="boost-banner">
+                            <a href="{{ event.subject_identity.urls.view }}">
+                                {{ event.subject_identity.html_name_or_handle }}
+                            </a> boosted
+                            <time>
+                                {{ event.subject_post_interaction.published | timedeltashort }} ago
+                            </time>
+                        </div>
+                        {% include "activities/_post.html" with post=event.subject_post %}
+                    {% endif %}
                 {% empty %}
                     <span class="empty">
                         {% if identity.local %}

--- a/users/views/identity.py
+++ b/users/views/identity.py
@@ -164,7 +164,12 @@ class IdentityFeed(Feed):
         return {"image": image}
 
     def items(self, identity: Identity):
-        return TimelineService(None).identity_public(identity)[:20]
+        return [
+            e.subject_post
+            for e in TimelineService(None).identity_public(
+                identity, include_boosts=False
+            )[:20]
+        ]
 
     def item_description(self, item: Post):
         return item.safe_content_remote()


### PR DESCRIPTION
As briefly discussed in the Discord, this is still really just a proposal, so feel free to just close it if this is either too early for a change like this, or if you'd rather approach the solution differently!

The resulting query is huge, but the query plan looks more or less alright to me. Note that I replaced the identity id with `{identity_id}`.

<details>
<summary>the huge query</summary>

```
SELECT "activities_timelineevent"."id",
       "activities_timelineevent"."identity_id",
       "activities_timelineevent"."type",
       "activities_timelineevent"."subject_post_id",
       "activities_timelineevent"."subject_post_interaction_id",
       "activities_timelineevent"."subject_identity_id",
       "activities_timelineevent"."published",
       "activities_timelineevent"."seen",
       "activities_timelineevent"."created",
       "activities_post"."state_ready",
       "activities_post"."state_changed",
       "activities_post"."state_attempted",
       "activities_post"."state_locked_until",
       "activities_post"."id",
       "activities_post"."author_id",
       "activities_post"."state",
       "activities_post"."local",
       "activities_post"."object_uri",
       "activities_post"."visibility",
       "activities_post"."content",
       "activities_post"."type",
       "activities_post"."type_data",
       "activities_post"."sensitive",
       "activities_post"."summary",
       "activities_post"."url",
       "activities_post"."in_reply_to",
       "activities_post"."hashtags",
       "activities_post"."stats",
       "activities_post"."published",
       "activities_post"."edited",
       "activities_post"."created",
       "activities_post"."updated",
       "users_identity"."state_ready",
       "users_identity"."state_changed",
       "users_identity"."state_attempted",
       "users_identity"."state_locked_until",
       "users_identity"."id",
       "users_identity"."actor_uri",
       "users_identity"."state",
       "users_identity"."local",
       "users_identity"."username",
       "users_identity"."domain_id",
       "users_identity"."name",
       "users_identity"."summary",
       "users_identity"."manually_approves_followers",
       "users_identity"."discoverable",
       "users_identity"."profile_uri",
       "users_identity"."inbox_uri",
       "users_identity"."shared_inbox_uri",
       "users_identity"."outbox_uri",
       "users_identity"."icon_uri",
       "users_identity"."image_uri",
       "users_identity"."followers_uri",
       "users_identity"."following_uri",
       "users_identity"."actor_type",
       "users_identity"."icon",
       "users_identity"."image",
       "users_identity"."metadata",
       "users_identity"."pinned",
       "users_identity"."sensitive",
       "users_identity"."restriction",
       "users_identity"."admin_notes",
       "users_identity"."private_key",
       "users_identity"."public_key",
       "users_identity"."public_key_id",
       "users_identity"."created",
       "users_identity"."updated",
       "users_identity"."fetched",
       "users_identity"."deleted",
       "users_domain"."state_ready",
       "users_domain"."state_changed",
       "users_domain"."state_attempted",
       "users_domain"."state_locked_until",
       "users_domain"."domain",
       "users_domain"."service_domain",
       "users_domain"."state",
       "users_domain"."nodeinfo",
       "users_domain"."local",
       "users_domain"."blocked",
       "users_domain"."public",
       "users_domain"."default",
       "users_domain"."notes",
       "users_domain"."created",
       "users_domain"."updated",
       "activities_postinteraction"."state_ready",
       "activities_postinteraction"."state_changed",
       "activities_postinteraction"."state_attempted",
       "activities_postinteraction"."state_locked_until",
       "activities_postinteraction"."id",
       "activities_postinteraction"."state",
       "activities_postinteraction"."object_uri",
       "activities_postinteraction"."type",
       "activities_postinteraction"."identity_id",
       "activities_postinteraction"."post_id",
       "activities_postinteraction"."value",
       "activities_postinteraction"."published",
       "activities_postinteraction"."created",
       "activities_postinteraction"."updated",
       T8."state_ready",
       T8."state_changed",
       T8."state_attempted",
       T8."state_locked_until",
       T8."id",
       T8."actor_uri",
       T8."state",
       T8."local",
       T8."username",
       T8."domain_id",
       T8."name",
       T8."summary",
       T8."manually_approves_followers",
       T8."discoverable",
       T8."profile_uri",
       T8."inbox_uri",
       T8."shared_inbox_uri",
       T8."outbox_uri",
       T8."icon_uri",
       T8."image_uri",
       T8."followers_uri",
       T8."following_uri",
       T8."actor_type",
       T8."icon",
       T8."image",
       T8."metadata",
       T8."pinned",
       T8."sensitive",
       T8."restriction",
       T8."admin_notes",
       T8."private_key",
       T8."public_key",
       T8."public_key_id",
       T8."created",
       T8."updated",
       T8."fetched",
       T8."deleted",
       T9."state_ready",
       T9."state_changed",
       T9."state_attempted",
       T9."state_locked_until",
       T9."domain",
       T9."service_domain",
       T9."state",
       T9."nodeinfo",
       T9."local",
       T9."blocked",
       T9."public",
       T9."default",
       T9."notes",
       T9."created",
       T9."updated",
       T4."state_ready",
       T4."state_changed",
       T4."state_attempted",
       T4."state_locked_until",
       T4."id",
       T4."actor_uri",
       T4."state",
       T4."local",
       T4."username",
       T4."domain_id",
       T4."name",
       T4."summary",
       T4."manually_approves_followers",
       T4."discoverable",
       T4."profile_uri",
       T4."inbox_uri",
       T4."shared_inbox_uri",
       T4."outbox_uri",
       T4."icon_uri",
       T4."image_uri",
       T4."followers_uri",
       T4."following_uri",
       T4."actor_type",
       T4."icon",
       T4."image",
       T4."metadata",
       T4."pinned",
       T4."sensitive",
       T4."restriction",
       T4."admin_notes",
       T4."private_key",
       T4."public_key",
       T4."public_key_id",
       T4."created",
       T4."updated",
       T4."fetched",
       T4."deleted",
       T10."state_ready",
       T10."state_changed",
       T10."state_attempted",
       T10."state_locked_until",
       T10."domain",
       T10."service_domain",
       T10."state",
       T10."nodeinfo",
       T10."local",
       T10."blocked",
       T10."public",
       T10."default",
       T10."notes",
       T10."created",
       T10."updated"
FROM "activities_timelineevent"
LEFT OUTER JOIN "activities_post" ON ("activities_timelineevent"."subject_post_id" = "activities_post"."id")
LEFT OUTER JOIN "users_identity" ON ("activities_post"."author_id" = "users_identity"."id")
LEFT OUTER JOIN "users_identity" T4 ON ("activities_timelineevent"."subject_identity_id" = T4."id")
LEFT OUTER JOIN "users_domain" ON ("users_identity"."domain_id" = "users_domain"."domain")
LEFT OUTER JOIN "activities_postinteraction" ON ("activities_timelineevent"."subject_post_interaction_id" = "activities_postinteraction"."id")
LEFT OUTER JOIN "users_identity" T8 ON ("activities_postinteraction"."identity_id" = T8."id")
LEFT OUTER JOIN "users_domain" T9 ON (T8."domain_id" = T9."domain")
LEFT OUTER JOIN "users_domain" T10 ON (T4."domain_id" = T10."domain")
WHERE ((("activities_post"."author_id" = {identity_id}
         AND "activities_post"."visibility" IN (0,
                                                4,
                                                1)
         AND "activities_timelineevent"."type" = 'post')
        OR ("activities_timelineevent"."subject_identity_id" = {identity_id}
            AND "activities_timelineevent"."type" = 'boost'))
       AND "activities_timelineevent"."identity_id" = {identity_id})
ORDER BY "activities_timelineevent"."created" DESC
LIMIT 25;
```

</details>

and the query plan:
```
 Limit  (cost=2.71..36.72 rows=1 width=7561) (actual time=0.049..0.052 rows=0 loops=1)
   ->  Nested Loop Left Join  (cost=2.71..36.72 rows=1 width=7561) (actual time=0.048..0.051 rows=0 loops=1)
         ->  Nested Loop Left Join  (cost=2.43..36.40 rows=1 width=7104) (actual time=0.047..0.050 rows=0 loops=1)
               ->  Nested Loop Left Join  (cost=2.15..36.08 rows=1 width=6647) (actual time=0.047..0.050 rows=0 loops=1)
                     ->  Nested Loop Left Join  (cost=1.86..34.22 rows=1 width=5046) (actual time=0.047..0.049 rows=0 loops=1)
                           ->  Nested Loop Left Join  (cost=1.57..25.91 rows=1 width=4869) (actual time=0.047..0.049 rows=0 loops=1)
                                 ->  Nested Loop Left Join  (cost=1.29..25.59 rows=1 width=4412) (actual time=0.046..0.048 rows=0 loops=1)
                                       ->  Nested Loop Left Join  (cost=1.00..17.28 rows=1 width=2811) (actual time=0.046..0.047 rows=0 loops=1)
                                             ->  Nested Loop Left Join  (cost=0.71..16.78 rows=1 width=1210) (actual time=0.046..0.047 rows=0 loops=1)
                                                   Filter: (((activities_post.author_id = '{identity_id}'::bigint) AND (activities_post.visibility = ANY ('{0,4,1}'::integer[])) AND ((activities_timelineevent.type)::text = 'post'::text)) OR ((activities_timelineevent.subject_identity_id = '{identity_id}'::bigint) AND ((activities_timelineevent.type)::text = 'boost'::text)))
                                                   ->  Index Scan Backward using activities_timelineevent_identity_id_created_d89f6538_idx on activities_timelineevent  (cost=0.29..8.31 rows=1 width=62) (actual time=0.040..0.041 rows=0 loops=1)
                                                         Index Cond: (identity_id = '{identity_id}'::bigint)
                                                         Filter: (((type)::text = 'post'::text) OR ((subject_identity_id = '{identity_id}'::bigint) AND ((type)::text = 'boost'::text)))
                                                   ->  Index Scan using activities_post_pkey on activities_post  (cost=0.42..8.44 rows=1 width=1148) (never executed)
                                                         Index Cond: (id = activities_timelineevent.subject_post_id)
                                             ->  Index Scan using users_identity_pkey on users_identity  (cost=0.29..0.51 rows=1 width=1601) (never executed)
                                                   Index Cond: (id = activities_post.author_id)
                                       ->  Index Scan using users_identity_pkey on users_identity t4  (cost=0.29..8.31 rows=1 width=1601) (never executed)
                                             Index Cond: (id = activities_timelineevent.subject_identity_id)
                                 ->  Index Scan using users_domain_pkey on users_domain  (cost=0.28..0.32 rows=1 width=457) (never executed)
                                       Index Cond: ((domain)::text = (users_identity.domain_id)::text)
                           ->  Index Scan using activities_postinteraction_pkey on activities_postinteraction  (cost=0.29..8.30 rows=1 width=177) (never executed)
                                 Index Cond: (id = activities_timelineevent.subject_post_interaction_id)
                     ->  Index Scan using users_identity_pkey on users_identity t8  (cost=0.29..1.86 rows=1 width=1601) (never executed)
                           Index Cond: (id = activities_postinteraction.identity_id)
               ->  Index Scan using users_domain_pkey on users_domain t9  (cost=0.28..0.32 rows=1 width=457) (never executed)
                     Index Cond: ((domain)::text = (t8.domain_id)::text)
         ->  Index Scan using users_domain_pkey on users_domain t10  (cost=0.28..0.32 rows=1 width=457) (never executed)
               Index Cond: ((domain)::text = (t4.domain_id)::text)
 Planning Time: 7.095 ms
 Execution Time: 0.893 ms
```

I have this branch deployed on my instance, my identity's profile looks like this: https://social.chdorner.com/@christof@chdorner.com/