### PR TITLE
Add `mention` class to user mention links

### DIFF
--- a/core/html.py
+++ b/core/html.py
@@ -196,7 +196,7 @@ class FediverseHtmlParser(HTMLParser):
                 self.mention_aliases[short_hash] = handle_hash
             elif self.mention_aliases.get(short_hash) != handle_hash:
                 short_handle = handle
-            return f'<a href="{html.escape(url)}">@{html.escape(short_handle)}</a>'
+            return f'<a href="{html.escape(url)}" class="mention">@{html.escape(short_handle)}</a>'
         else:
             return "@" + html.escape(handle)
 

--- a/tests/activities/models/test_post.py
+++ b/tests/activities/models/test_post.py
@@ -101,7 +101,7 @@ def test_linkify_mentions_remote(
     post.mentions.add(remote_identity)
     assert (
         post.safe_content_remote()
-        == '<p>Hello <a href="https://remote.test/@test/">@test</a></p>'
+        == '<p>Hello <a href="https://remote.test/@test/" class="mention">@test</a></p>'
     )
     # Test a full username (local)
     post = Post.objects.create(
@@ -112,7 +112,7 @@ def test_linkify_mentions_remote(
     post.mentions.add(identity)
     assert (
         post.safe_content_remote()
-        == '<p><a href="https://example.com/@test/">@test</a>, welcome!</p>'
+        == '<p><a href="https://example.com/@test/" class="mention">@test</a>, welcome!</p>'
     )
     # Test that they don't get touched without a mention
     post = Post.objects.create(
@@ -131,7 +131,7 @@ def test_linkify_mentions_remote(
     post.mentions.add(remote_identity)
     assert (
         post.safe_content_remote()
-        == '<p>Hey <a href="https://remote.test/@test/">@TeSt</a></p>'
+        == '<p>Hey <a href="https://remote.test/@test/" class="mention">@TeSt</a></p>'
     )
 
     # Test trailing dot (remote)
@@ -143,7 +143,7 @@ def test_linkify_mentions_remote(
     post.mentions.add(remote_identity)
     assert (
         post.safe_content_remote()
-        == '<p>Hey <a href="https://remote.test/@test/">@test</a>.</p>'
+        == '<p>Hey <a href="https://remote.test/@test/" class="mention">@test</a>.</p>'
     )
 
     # Test that collapsing only applies to the first unique, short username
@@ -154,15 +154,15 @@ def test_linkify_mentions_remote(
     )
     post.mentions.set([remote_identity, remote_identity2])
     assert post.safe_content_remote() == (
-        '<p>Hey <a href="https://remote.test/@test/">@TeSt</a> '
-        'and <a href="https://remote2.test/@test/">@test@remote2.test</a></p>'
+        '<p>Hey <a href="https://remote.test/@test/" class="mention">@TeSt</a> '
+        'and <a href="https://remote2.test/@test/" class="mention">@test@remote2.test</a></p>'
     )
 
     post.content = "<p>Hey @TeSt, @Test@remote.test and @test</p>"
     assert post.safe_content_remote() == (
-        '<p>Hey <a href="https://remote2.test/@test/">@TeSt</a>, '
-        '<a href="https://remote.test/@test/">@Test@remote.test</a> '
-        'and <a href="https://remote2.test/@test/">@test</a></p>'
+        '<p>Hey <a href="https://remote2.test/@test/" class="mention">@TeSt</a>, '
+        '<a href="https://remote.test/@test/" class="mention">@Test@remote.test</a> '
+        'and <a href="https://remote2.test/@test/" class="mention">@test</a></p>'
     )
 
 
@@ -180,7 +180,7 @@ def test_linkify_mentions_local(config_system, identity, identity2, remote_ident
     post.mentions.add(remote_identity)
     assert (
         post.safe_content_local()
-        == '<p>Hello <a href="/@test@remote.test/">@test</a></p>'
+        == '<p>Hello <a href="/@test@remote.test/" class="mention">@test</a></p>'
     )
     # Test a full username (local)
     post = Post.objects.create(
@@ -191,9 +191,9 @@ def test_linkify_mentions_local(config_system, identity, identity2, remote_ident
     post.mentions.add(identity)
     post.mentions.add(identity2)
     assert post.safe_content_local() == (
-        '<p><a href="/@test@example.com/">@test</a>, welcome!'
-        ' <a href="/@test@example2.com/">@test@example2.com</a>'
-        ' <a href="/@test@example.com/">@test</a></p>'
+        '<p><a href="/@test@example.com/" class="mention">@test</a>, welcome!'
+        ' <a href="/@test@example2.com/" class="mention">@test@example2.com</a>'
+        ' <a href="/@test@example.com/" class="mention">@test</a></p>'
     )
     # Test a full username (remote) with no <p>
     post = Post.objects.create(
@@ -202,7 +202,10 @@ def test_linkify_mentions_local(config_system, identity, identity2, remote_ident
         local=True,
     )
     post.mentions.add(remote_identity)
-    assert post.safe_content_local() == '<a href="/@test@remote.test/">@test</a> hello!'
+    assert (
+        post.safe_content_local()
+        == '<a href="/@test@remote.test/" class="mention">@test</a> hello!'
+    )
     # Test that they don't get touched without a mention
     post = Post.objects.create(
         content="<p>@test@example.com, welcome!</p>",

--- a/tests/api/test_statuses.py
+++ b/tests/api/test_statuses.py
@@ -71,7 +71,7 @@ def test_mention_format(api_client, identity, remote_identity):
     ).json()
     assert (
         response["content"]
-        == '<p>Hello, <a href="https://example.com/@test/">@test</a>!</p>'
+        == '<p>Hello, <a href="https://example.com/@test/" class="mention">@test</a>!</p>'
     )
     assert response["visibility"] == "unlisted"
 
@@ -87,7 +87,8 @@ def test_mention_format(api_client, identity, remote_identity):
         f"/api/v1/statuses/{post.id}",
     ).json()
     assert (
-        response["text"] == '<p>Hey <a href="https://example.com/@test/">@test</a></p>'
+        response["text"]
+        == '<p>Hey <a href="https://example.com/@test/" class="mention">@test</a></p>'
     )
 
 

--- a/tests/core/test_html.py
+++ b/tests/core/test_html.py
@@ -79,7 +79,9 @@ def test_parser(identity):
         find_hashtags=True,
         find_emojis=True,
     )
-    assert parser.html == '<p><a href="/@test@example.com/">@test</a></p>'
+    assert (
+        parser.html == '<p><a href="/@test@example.com/" class="mention">@test</a></p>'
+    )
     assert parser.plain_text == "@test@example.com"
     assert parser.mentions == {"test@example.com"}
 
@@ -90,7 +92,9 @@ def test_parser(identity):
         find_hashtags=True,
         find_emojis=True,
     )
-    assert parser.html == '<p><a href="/@test@example.com/">@TeSt</a></p>'
+    assert (
+        parser.html == '<p><a href="/@test@example.com/" class="mention">@TeSt</a></p>'
+    )
     assert parser.plain_text == "@TeSt@ExamPle.com"
     assert parser.mentions == {"test@example.com"}
 
@@ -131,6 +135,6 @@ def test_parser_same_name_mentions(remote_identity, remote_identity2):
     )
     assert (
         parser.html
-        == '<a href="/@test@remote.test/">@test</a> <a href="/@test@remote2.test/">@test</a>'
+        == '<a href="/@test@remote.test/" class="mention">@test</a> <a href="/@test@remote2.test/" class="mention">@test</a>'
     )
     assert parser.plain_text == "@test @test"


### PR DESCRIPTION
This should fix mention links in Elk to keep linking inside Elk, not to the instance of the mentioned user.

Elk was failing to detect a user mention in this if statement: https://github.com/elk-zone/elk/blob/fc97e8ff5b5ad077417a32440a978e49b8449cc0/composables/content-render.ts#L88

I could've sworn that this was working up until recently, but none of the code responsible on both the Takahe and the Elk side has changed in months.