### PR TITLE
Fix hashtag search results

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -275,7 +275,7 @@ class Notification(Schema):
 class Tag(Schema):
     name: str
     url: str
-    history: dict
+    history: list
     following: bool | None
 
     @classmethod

--- a/api/views/search.py
+++ b/api/views/search.py
@@ -39,7 +39,7 @@ def search(
             for i in search_result["identities"]
         ]
     if type is None or type == "hashtag":
-        result["hashtag"] = [
+        result["hashtags"] = [
             schemas.Tag.from_hashtag(h) for h in search_result["hashtags"]
         ]
     if type is None or type == "statuses":


### PR DESCRIPTION
We mistakenly wrote to the key "hashtag" instead of "hashtags", resulting in no results in the API response. Additionally, the type of the Tag's `history` needs to be a list, not a dict.

This fixes hashtag search in Elk:

<img width="293" alt="image" src="https://github.com/jointakahe/takahe/assets/112063/46cff3e7-7919-4e34-bfb5-39e63a1abae2">

We still don't have the history, which Elk then renders as "0 people in the past 2 days".