### PR TITLE
Fixes various issues with pinned posts

### DIFF
--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -760,15 +760,22 @@ class Identity(StatorModel):
 
         try:
             data = canonicalise(response.json(), include_security=True)
+            items: list[dict | str] = []
             if "orderedItems" in data:
-                return [
-                    item["id"]
-                    for item in reversed(data["orderedItems"])
-                    if isinstance(item, dict)
-                ]
+                items = list(reversed(data["orderedItems"]))
             elif "items" in data:
-                return [item["id"] for item in data["items"] if isinstance(item, dict)]
-            return []
+                items = list(data["items"])
+
+            ids = []
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                post_obj: dict | None = item
+                if item["type"] == "Create":
+                    post_obj = item.get("object")
+                if post_obj:
+                    ids.append(post_obj["id"])
+            return ids
         except ValueError:
             # Some servers return these with a 200 status code!
             if b"not found" in response.content.lower():

--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -761,9 +761,13 @@ class Identity(StatorModel):
         try:
             data = canonicalise(response.json(), include_security=True)
             if "orderedItems" in data:
-                return [item["id"] for item in reversed(data["orderedItems"])]
+                return [
+                    item["id"]
+                    for item in reversed(data["orderedItems"])
+                    if isinstance(item, dict)
+                ]
             elif "items" in data:
-                return [item["id"] for item in data["items"]]
+                return [item["id"] for item in data["items"] if isinstance(item, dict)]
             return []
         except ValueError:
             # Some servers return these with a 200 status code!

--- a/users/services/identity.py
+++ b/users/services/identity.py
@@ -185,7 +185,7 @@ class IdentityService:
         }
 
     def sync_pins(self, object_uris):
-        if not object_uris:
+        if not object_uris or self.identity.domain.blocked:
             return
 
         with transaction.atomic():


### PR DESCRIPTION
Now that this has been running on my instance for a while, I'm seeing a few issues with different servers and implementations.

1. Syncing pinned items for an identity on a blocked domain fails, probably fine to just skip syncing the featured collection when an identity from a blocked domain is outdated
2. Some Mastodon featured collections either include only URLs to posts, or a mix of embedded objects and URLs. Whenever I follow the URLs, they lead to a 404, so probably safe to ignore non-dict featured collection items.
    - Example of only URLs: `curl -H "Accept: application/activity+json" https://hachyderm.io/users/tiff/collections/featured | jq .`
    - Example of mixed types: `curl -H "Accept: application/activity+json" https://octodon.social/users/Eramdam/collections/featured | jq .`
3. Friendica featured collections contain `Create` activities, not the `Notes` by themselves. Mastodon seems to be skipping those, I've opted for importing those
    - Example: `curl -H "Accept: application/activity+json" https://art1sec.uber.space/featured/martin | jq .`