### PR TITLE
Fixes various issues with pinned posts - continued

### DIFF
--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -771,7 +771,7 @@ class Identity(StatorModel):
                 if not isinstance(item, dict):
                     continue
                 post_obj: dict | None = item
-                if item["type"] == "Create":
+                if item["type"] in ["Create", "Update"]:
                     post_obj = item.get("object")
                 if post_obj:
                     ids.append(post_obj["id"])

--- a/users/services/identity.py
+++ b/users/services/identity.py
@@ -190,13 +190,17 @@ class IdentityService:
 
         with transaction.atomic():
             for object_uri in object_uris:
-                post = Post.by_object_uri(object_uri, fetch=True)
-                PostInteraction.objects.get_or_create(
-                    type=PostInteraction.Types.pin,
-                    identity=self.identity,
-                    post=post,
-                    state__in=PostInteractionStates.group_active(),
-                )
+                try:
+                    post = Post.by_object_uri(object_uri, fetch=True)
+                    PostInteraction.objects.get_or_create(
+                        type=PostInteraction.Types.pin,
+                        identity=self.identity,
+                        post=post,
+                        state__in=PostInteractionStates.group_active(),
+                    )
+                except Post.DoesNotExist:
+                    # ignore 404s...
+                    pass
             for removed in PostInteraction.objects.filter(
                 type=PostInteraction.Types.pin,
                 identity=self.identity,


### PR DESCRIPTION
Found another 2 problems:

1. Sometimes the object URI of an item in a featured collections results in a 404, I've seen this either with Mastodon (presumably more of an access issue rather than actual 404?) or with some homegrown-ish blogging platform. I thought it's safe to just ignore those and allow the identity to transition from outdated to updated
    - since we use the `Post.DoesNotExist` also for other errors, this will also ignore those, i.e. SSL errors, >500 response codes, etc.
2. Friendica doesn't just have `Create` activities in featured collections, but also `Update`. I hope there won't be additional ones

I'll keep an eye on Sentry in the next few days and raise additional PRs if I see more errors coming in.