### PR TITLE
Use post id to generate summary class

### DIFF
--- a/activities/models/post.py
+++ b/activities/models/post.py
@@ -1,5 +1,4 @@
 import datetime
-import hashlib
 import json
 import mimetypes
 import ssl

--- a/activities/models/post.py
+++ b/activities/models/post.py
@@ -436,7 +436,7 @@ class Post(StatorModel):
         """
         if not self.summary:
             return ""
-        return "summary-" + hashlib.md5(self.summary.encode("utf8")).hexdigest()
+        return "summary-{self.id}"
 
     @property
     def stats_with_defaults(self):


### PR DESCRIPTION
Use the post's id to uniquely identify the summary class.

Currently we hash the name of the summary to generate the unique css class name, which causes all summaries with the same name to expand and close together (was this behaviour intentional?)

Example: https://fedi.karthikbalakrishnan.com/@me@karthikbalakrishnan.com/posts/182274944255353776/

https://github.com/jointakahe/takahe/assets/3104454/287501d3-6875-45f8-8c2c-164e78ba76c7


