### PR TITLE
Prevent dropping ellipsis URL

### DIFF
--- a/core/html.py
+++ b/core/html.py
@@ -169,7 +169,7 @@ class FediverseHtmlParser(HTMLParser):
         if looks_like_link:
             content = content.split("://", 1)[1]
         if (looks_like_link and len(content) > 30) or has_ellipsis:
-            return f'<a href="{html.escape(href)}" rel="nofollow" class="ellipsis" title="{html.escape(content)}">{html.escape(content[:30])}</a>'
+            return f'<a href="{html.escape(href)}" rel="nofollow" class="ellipsis" title="{html.escape(content)}"><span class="ellipsis">{html.escape(content[:30])}</span><span class="invisible">{html.escape(content[30:])}</span></a>'
         else:
             return f'<a href="{html.escape(href)}" rel="nofollow">{html.escape(content)}</a>'
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -394,7 +394,7 @@ img.emoji {
     vertical-align: baseline;
 }
 
-.ellipsis::after {
+span.ellipsis::after {
     content: "…";
 }
 
@@ -1483,6 +1483,10 @@ form .post {
 
 .post .content p {
     margin: 12px 0 4px 0;
+}
+
+.post .content p a .invisible {
+    display: none;
 }
 
 .post .attachments {

--- a/tests/api/test_statuses.py
+++ b/tests/api/test_statuses.py
@@ -155,3 +155,23 @@ def test_question_format(api_client, remote_identity):
         ],
         "emojis": [],
     }
+
+
+@pytest.mark.django_db
+def test_content_link(api_client, identity, remote_identity):
+    """
+    Ensures mentions work, and only have one link around them.
+    """
+    # Make a local post and check it
+    response = api_client.post(
+        "/api/v1/statuses",
+        data={
+            "status": "Takahē - return to the wild - https://www.youtube.com/watch?v=IG423K3pmQI",
+        },
+    ).json()
+
+    # temp fix
+    assert (
+        response["content"]
+        == '<p>Takahē - return to the wild - <a href="https://www.youtube.com/watch?v=IG423K3pmQI" rel="nofollow" class="ellipsis" title="www.youtube.com/watch?v=IG423K3pmQI"><span class="ellipsis">www.youtube.com/watch?v=IG423K</span><span class="invisible">3pmQI</span></a></p>'
+    )

--- a/tests/core/test_html.py
+++ b/tests/core/test_html.py
@@ -54,7 +54,7 @@ def test_parser(identity):
     parser = FediverseHtmlParser(f"<p>{full_url}</p>")
     assert (
         parser.html
-        == f'<p><a href="{full_url}" rel="nofollow" class="ellipsis" title="{full_url.removeprefix("https://")}">social.example.com/a-long/path</a></p>'
+        == f'<p><a href="{full_url}" rel="nofollow" class="ellipsis" title="{full_url.removeprefix("https://")}"><span class="ellipsis">social.example.com/a-long/path</span><span class="invisible">/that-should-be-shortened</span></a></p>'
     )
     assert (
         parser.plain_text


### PR DESCRIPTION
fixes #584

This issue seems to occur because Elk uses the textContent of the Mastodon HTML as a draft text (ref. [1](https://github.com/elk-zone/elk/blob/main/components/status/StatusActionsMore.vue#L110-L110), [2](https://github.com/elk-zone/elk/blob/main/composables/content-parse.ts#L145), [3](https://github.com/elk-zone/elk/blob/main/composables/masto/statusDrafts.ts#L61), [4](https://github.com/elk-zone/elk/blob/main/composables/content-parse.ts#L76-L76)) and we are dropping the remaining URL string after 30 characters.

Here is an example `content` comparisons between Mastodon (first) and Takahē API (second):

```diff
-    "content": "<p>Takahē - return to the wild - <a href=\"https://www.youtube.com/watch?v=IG423K3pmQI\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://www.</span><span class=\"ellipsis\">youtube.com/watch?v=IG423K3pmQ</span><span class=\"invisible\">I</span></a></p>",
+    "content": "<p>Takahē - return to the wild - <a href=\"https://www.youtube.com/watch?v=IG423K3pmQI\" rel=\"nofollow\" class=\"ellipsis\" title=\"www.youtube.com/watch?v=IG423K\">www.youtube.com/watch?v=IG423K</a></p>",
```

To emulate Mastodon's link in `content`, this wraps the URL text with `<span class="ellipsis">` and `<span class="invisible">`.

I kept the `class="ellipsis"` of the `<a>` tag untouched as I don't fully understand how it affects other parts of logic yet.

<img width="1526" alt="Screenshot 2023-05-24 at 21 55 54" src="https://github.com/jointakahe/takahe/assets/1425259/ba4b1859-d76d-4e98-8831-dadac2f20eb5">

https://takahe.shuuji3.xyz/@shuuji3@takahe.shuuji3.xyz/posts/184178424987558872/

<img width="1506" alt="Screenshot 2023-05-24 at 21 56 59" src="https://github.com/jointakahe/takahe/assets/1425259/833e2b71-da37-4ab0-9a37-959e3ba07302">
<img width="1500" alt="Screenshot 2023-05-24 at 21 58 06" src="https://github.com/jointakahe/takahe/assets/1425259/6bd0520f-e661-4821-98ce-98eed5e9630d">

https://elk.zone/takahe.shuuji3.xyz/@shuuji3/184178424987558872