### PR TITLE
Prevent dropping ellipsis URL

### DIFF
--- a/core/html.py
+++ b/core/html.py
@@ -167,9 +167,13 @@ class FediverseHtmlParser(HTMLParser):
         """
         looks_like_link = bool(self.URL_REGEX.match(content))
         if looks_like_link:
-            content = content.split("://", 1)[1]
+            protocol, content = content.split("://", 1)
+        else:
+            protocol = ""
         if (looks_like_link and len(content) > 30) or has_ellipsis:
-            return f'<a href="{html.escape(href)}" rel="nofollow" class="ellipsis" title="{html.escape(content)}"><span class="ellipsis">{html.escape(content[:30])}</span><span class="invisible">{html.escape(content[30:])}</span></a>'
+            return f'<a href="{html.escape(href)}" rel="nofollow" class="ellipsis" title="{html.escape(content)}"><span class="invisible">{html.escape(protocol)}://</span><span class="ellipsis">{html.escape(content[:30])}</span><span class="invisible">{html.escape(content[30:])}</span></a>'
+        elif looks_like_link:
+            return f'<a href="{html.escape(href)}" rel="nofollow"><span class="invisible">{html.escape(protocol)}://</span>{html.escape(content)}</a>'
         else:
             return f'<a href="{html.escape(href)}" rel="nofollow">{html.escape(content)}</a>'
 

--- a/tests/api/test_statuses.py
+++ b/tests/api/test_statuses.py
@@ -170,8 +170,7 @@ def test_content_link(api_client, identity, remote_identity):
         },
     ).json()
 
-    # temp fix
     assert (
         response["content"]
-        == '<p>Takahē - return to the wild - <a href="https://www.youtube.com/watch?v=IG423K3pmQI" rel="nofollow" class="ellipsis" title="www.youtube.com/watch?v=IG423K3pmQI"><span class="ellipsis">www.youtube.com/watch?v=IG423K</span><span class="invisible">3pmQI</span></a></p>'
+        == '<p>Takahē - return to the wild - <a href="https://www.youtube.com/watch?v=IG423K3pmQI" rel="nofollow" class="ellipsis" title="www.youtube.com/watch?v=IG423K3pmQI"><span class="invisible">https://</span><span class="ellipsis">www.youtube.com/watch?v=IG423K</span><span class="invisible">3pmQI</span></a></p>'
     )

--- a/tests/core/test_html.py
+++ b/tests/core/test_html.py
@@ -37,7 +37,8 @@ def test_parser(identity):
     assert parser.plain_text == "test.com"
     parser = FediverseHtmlParser("<p>https://test.com</p>")
     assert (
-        parser.html == '<p><a href="https://test.com" rel="nofollow">test.com</a></p>'
+        parser.html
+        == '<p><a href="https://test.com" rel="nofollow"><span class="invisible">https://</span>test.com</a></p>'
     )
     assert parser.plain_text == "https://test.com"
 
@@ -54,7 +55,7 @@ def test_parser(identity):
     parser = FediverseHtmlParser(f"<p>{full_url}</p>")
     assert (
         parser.html
-        == f'<p><a href="{full_url}" rel="nofollow" class="ellipsis" title="{full_url.removeprefix("https://")}"><span class="ellipsis">social.example.com/a-long/path</span><span class="invisible">/that-should-be-shortened</span></a></p>'
+        == f'<p><a href="{full_url}" rel="nofollow" class="ellipsis" title="{full_url.removeprefix("https://")}"><span class="invisible">https://</span><span class="ellipsis">social.example.com/a-long/path</span><span class="invisible">/that-should-be-shortened</span></a></p>'
     )
     assert (
         parser.plain_text


### PR DESCRIPTION
Hello, this is a follow-up PR for #585.

I focused on the ellipsis part of the URL in the last PR and missed including the first protocol part like `https://` as an invisible text. Without it, Elk still failed to recover the complete URL after saving the edited post (for example, `https://takahe.social` became a plain text `takahe.social`).

Now:
<img width="863" alt="Screenshot 2023-05-26 at 16 54 26" src="https://github.com/jointakahe/takahe/assets/1425259/39da1746-875f-4f58-89b7-9a9cb1da2899">
