### PR TITLE
Bugfix admin redirect fixes

### DIFF
--- a/templates/admin/announcement_edit.html
+++ b/templates/admin/announcement_edit.html
@@ -16,7 +16,7 @@
             {% include "forms/_field.html" with field=form.end %}
         </fieldset>
         <div class="buttons">
-            <a href="{{ announcement.urls.admin_root }}" class="button secondary left">Back</a>
+            <a href="{{ announcement.urls.admin_root }}?page={{ page }}" class="button secondary left">Back</a>
             <a href="{{ announcement.urls.admin_delete }}" class="button delete">Delete</a>
             <button>Save</button>
         </div>

--- a/templates/admin/announcements.html
+++ b/templates/admin/announcements.html
@@ -10,11 +10,11 @@
         {% for announcement in page_obj %}
             <tr>
                 <td class="icon">
-                    <a href="{{ announcement.urls.admin_edit }}" class="overlay"></a>
+                    <a href="{{ announcement.urls.admin_edit }}?page={{ page_obj.number }}" class="overlay"></a>
                     <i class="fa-solid fa-bullhorn"></i>
                 </td>
                 <td class="name">
-                    <a href="{{ announcement.urls.admin_edit }}" class="overlay"></a>
+                    <a href="{{ announcement.urls.admin_edit }}?page={{ page_obj.number }}" class="overlay"></a>
                     {{ announcement.html|truncatewords_html:"10" }}
                     <small>
                         {% if announcement.service_announcement %}{{ domain.service_domain }}{% endif %}

--- a/templates/admin/federation.html
+++ b/templates/admin/federation.html
@@ -12,11 +12,11 @@
         {% for domain in page_obj %}
             <tr>
                 <td class="icon">
-                    <a href="{{ domain.urls.edit_federation }}" class="overlay"></a>
+                    <a href="{{ domain.urls.edit_federation }}?page={{ page_obj.number }}" class="overlay"></a>
                     <i class="fa-solid fa-globe"></i>
                 </td>
                 <td class="name">
-                    <a href="{{ domain.urls.edit_federation }}" class="overlay"></a>
+                    <a href="{{ domain.urls.edit_federation }}?page={{ page_obj.number }}" class="overlay"></a>
                     {{ domain.domain }}
                     <small>{{ domain.software }}</small>
                 </td>

--- a/templates/admin/federation_edit.html
+++ b/templates/admin/federation_edit.html
@@ -15,7 +15,7 @@
             {% include "forms/_field.html" with field=form.notes %}
         </fieldset>
         <div class="buttons">
-            <a href="{{ domain.urls.root_federation }}" class="button secondary left">Back</a>
+            <a href="{{ domain.urls.root_federation }}?page={{ page }}" class="button secondary left">Back</a>
             <a href="{{ domain.urls.delete }}" class="button delete">Delete</a>
             <button>Save</button>
         </div>

--- a/templates/admin/hashtag_edit.html
+++ b/templates/admin/hashtag_edit.html
@@ -38,7 +38,7 @@
             </div>
         </fieldset>
         <div class="buttons">
-            <a href="{{ hashtag.urls.admin }}" class="button secondary left">Back</a>
+            <a href="{{ hashtag.urls.admin }}?page={{ page }}" class="button secondary left">Back</a>
             <a href="{{ hashtag.urls.timeline }}" class="button secondary">View Posts</a>
             <button>Save</button>
         </div>

--- a/templates/admin/hashtags.html
+++ b/templates/admin/hashtags.html
@@ -7,11 +7,11 @@
         {% for hashtag in page_obj %}
             <tr>
                 <td class="icon">
-                    <a href="{{ hashtag.urls.admin_edit }}" class="overlay"></a>
+                    <a href="{{ hashtag.urls.admin_edit }}?page={{ page_obj.number }}" class="overlay"></a>
                     <i class="fa-solid fa-hashtag"></i>
                 </td>
                 <td class="name">
-                    <a href="{{ hashtag.urls.admin_edit }}" class="overlay"></a>
+                    <a href="{{ hashtag.urls.admin_edit }}?page={{ page_obj.number }}" class="overlay"></a>
                     {{ hashtag.display_name }}
                     <small>{% if hashtag.public %}Public{% elif hashtag.public is None %}Unreviewed{% else %}Private{% endif %}</small>
                 </td>

--- a/templates/admin/identities.html
+++ b/templates/admin/identities.html
@@ -22,7 +22,7 @@
         {% for identity in page_obj %}
             <tr>
                 <td class="icon">
-                    <a href="{{ identity.urls.admin_edit }}" class="overlay"></a>
+                    <a href="{{ identity.urls.admin_edit }}?page={{ page_obj.number }}" class="overlay"></a>
                     <img
                         src="{{ identity.local_icon_url.relative }}"
                         class="icon"
@@ -33,7 +33,7 @@
                     >
                 </td>
                 <td class="name">
-                    <a href="{{ identity.urls.admin_edit }}" class="overlay"></a>
+                    <a href="{{ identity.urls.admin_edit }}?page={{ page_obj.number }}" class="overlay"></a>
                     {{ identity.html_name_or_handle }}
                     <small>@{{ identity.handle }}</small>
                 </td>

--- a/templates/admin/identity_edit.html
+++ b/templates/admin/identity_edit.html
@@ -115,7 +115,7 @@
             {% endif %}
         </div>
         <div class="buttons">
-            <a href="{{ identity.urls.admin }}" class="button secondary left">Back</a>
+            <a href="{{ identity.urls.admin }}?page={{ page }}" class="button secondary left">Back</a>
             <a href="{{ identity.urls.view }}" class="button secondary">View Profile</a>
             <button>Save Notes</button>
         </div>

--- a/templates/admin/invite_view.html
+++ b/templates/admin/invite_view.html
@@ -13,7 +13,7 @@
             {% include "forms/_field.html" with field=form.notes %}
         </fieldset>
         <div class="buttons">
-            <a href="{% url "admin_invites" %}" class="button secondary left">Back</a>
+            <a href="{% url 'admin_invites' %}?page={{ page }}" class="button secondary left">Back</a>
             <button class="delete" name="delete">Delete</button>
             <button>Save</button>
         </div>

--- a/templates/admin/invites.html
+++ b/templates/admin/invites.html
@@ -12,11 +12,11 @@
         {% for invite in page_obj %}
             <tr>
                 <td class="icon">
-                    <a href="{{ invite.urls.admin_view }}" class="overlay"></a>
+                    <a href="{{ invite.urls.admin_view }}?page={{ page_obj.number }}" class="overlay"></a>
                     <i class="fa-solid fa-envelope"></i>
                 </td>
                 <td class="name">
-                    <a href="{{ invite.urls.admin_view }}" class="overlay"></a>
+                    <a href="{{ invite.urls.admin_view }}?page={{ page_obj.number }}" class="overlay"></a>
                     {{ invite.token }}
                     <small>
                         {% if invite.note %}

--- a/templates/admin/report_view.html
+++ b/templates/admin/report_view.html
@@ -77,7 +77,7 @@
             </table>
         </fieldset>
         <div class="buttons">
-            <a href="{{ report.urls.admin }}" class="button secondary left">Back</a>
+            <a href="{{ report.urls.admin }}?page={{ page }}" class="button secondary left">Back</a>
             <a href="{{ report.subject_identity.urls.view }}" class="button secondary">View Profile</a>
             <a href="{{ report.subject_identity.urls.admin_edit }}" class="button secondary">Identity Admin</a>
             <button>Save Notes</button>

--- a/templates/admin/reports.html
+++ b/templates/admin/reports.html
@@ -15,11 +15,11 @@
         {% for report in page_obj %}
             <tr>
                 <td class="icon">
-                    <a href="{{ report.urls.admin_view }}" class="overlay"></a>
+                    <a href="{{ report.urls.admin_view }}?page={{ page_obj.number }}" class="overlay"></a>
                     <img src="{{ report.subject_identity.local_icon_url.relative }}" class="icon" alt="Avatar for {{ report.subject_identity.name_or_handle }}">
                 </td>
                 <td class="name">
-                    <a href="{{ report.urls.admin_view }}" class="overlay"></a>
+                    <a href="{{ report.urls.admin_view }}?page={{ page_obj.number }}" class="overlay"></a>
                     {{ report.subject_identity.html_name_or_handle }}
                     {% if report.subject_post %}
                         <small>

--- a/templates/admin/user_edit.html
+++ b/templates/admin/user_edit.html
@@ -29,7 +29,7 @@
             <p>Created: <time title="{{ editing_user.created }} UTC">{{ editing_user.created | timesince }} ago</time></p>
         </fieldset>
         <div class="buttons">
-            <a href="{{ editing_user.urls.admin }}" class="button secondary left">Back</a>
+            <a href="{{ editing_user.urls.admin }}?page={{ page }}" class="button secondary left">Back</a>
             <button>Save</button>
         </div>
     </form>

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -12,11 +12,11 @@
         {% for user in page_obj %}
             <tr>
                 <td class="icon">
-                    <a href="{{ user.urls.admin_edit }}" class="overlay"></a>
+                    <a href="{{ user.urls.admin_edit }}?page={{ page_obj.number }}" class="overlay"></a>
                     <i class="fa-solid fa-user"></i>
                 </td>
                 <td class="name">
-                    <a href="{{ user.urls.admin_edit }}" class="overlay"></a>
+                    <a href="{{ user.urls.admin_edit }}?page={{ page_obj.number }}" class="overlay"></a>
                     {{ user.email }}
                     <small>{% if user.admin %}Admin{% elif user.moderator %}Moderator{% endif %}</small>
                 </td>

--- a/users/views/admin/announcements.py
+++ b/users/views/admin/announcements.py
@@ -49,7 +49,11 @@ class AnnouncementEdit(UpdateView):
     model = Announcement
     template_name = "admin/announcement_edit.html"
     extra_context = {"section": "announcements"}
-    success_url = Announcement.urls.admin_root
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page"] = self.request.GET.get("page")
+        return context
 
     class form_class(AnnouncementCreate.form_class):
         pass

--- a/users/views/admin/federation.py
+++ b/users/views/admin/federation.py
@@ -64,6 +64,7 @@ class FederationEdit(FormView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context["domain"] = self.domain
+        context["page"] = self.request.GET.get("page")
         return context
 
     def form_valid(self, form):

--- a/users/views/admin/hashtags.py
+++ b/users/views/admin/hashtags.py
@@ -64,6 +64,7 @@ class HashtagEdit(FormView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context["hashtag"] = self.hashtag
+        context["page"] = self.request.GET.get("page")
         return context
 
     def form_valid(self, form):

--- a/users/views/admin/identities.py
+++ b/users/views/admin/identities.py
@@ -90,4 +90,5 @@ class IdentityEdit(FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["identity"] = self.identity
+        context["page"] = self.request.GET.get("page")
         return context

--- a/users/views/admin/invites.py
+++ b/users/views/admin/invites.py
@@ -106,4 +106,5 @@ class InviteView(FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["invite"] = self.invite
+        context["page"] = self.request.GET.get("page")
         return context

--- a/users/views/admin/reports.py
+++ b/users/views/admin/reports.py
@@ -77,4 +77,5 @@ class ReportView(FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["report"] = self.report
+        context["page"] = self.request.GET.get("page")
         return context

--- a/users/views/admin/users.py
+++ b/users/views/admin/users.py
@@ -81,4 +81,5 @@ class UserEdit(FormView):
         context = super().get_context_data(**kwargs)
         context["editing_user"] = self.user
         context["same_user"] = self.user == self.request.user
+        context["page"] = self.request.GET.get("page")
         return context


### PR DESCRIPTION
fixes jointakahe/takahe#285

Return to the correct page on a paginated list in the admin section after visiting a detail page it contains.

1. Set the list page index as a GET parameter in the href used to link to the detail page.
2. Capture the list page index in the `View` when creating the context
3. Set the list page index from the context as a GET parameter on the `back` link on the detail page

Works for:
- [x]  announcements
- [x]  federation
- [x]  hashtags
- [x]  identities
- [x]  invites
- [x]  reports
- [x]  users