### PR TITLE
Fix metadata not being updated in Mastodon instances

### DIFF
--- a/api/views/accounts.py
+++ b/api/views/accounts.py
@@ -11,7 +11,7 @@ from api import schemas
 from api.decorators import scope_required
 from api.pagination import MastodonPaginator, PaginatingApiResponse, PaginationResult
 from core.models import Config
-from users.models import Identity
+from users.models import Identity, IdentityStates
 from users.services import IdentityService
 from users.shortcuts import by_handle_or_404
 
@@ -70,6 +70,7 @@ def update_credentials(
     if header:
         service.set_image(header)
     identity.save()
+    identity.transition_perform(IdentityStates.edited)
     return schemas.Account.from_identity(identity, source=True)
 
 

--- a/tests/users/models/test_identity.py
+++ b/tests/users/models/test_identity.py
@@ -240,3 +240,31 @@ async def test_fetch_webfinger_url(httpx_mock: HTTPXMock, config_system):
         await Identity.fetch_webfinger_url("example.com")
         == "https://example.com/.well-known/webfinger?resource={uri}"
     )
+
+
+@pytest.mark.django_db
+def test_attachment_to_ap(identity: Identity, config_system):
+    """
+    Tests identity attachment conversion to AP format.
+    """
+    identity.metadata = [
+        {
+            "type": "http://schema.org#PropertyValue",
+            "name": "Website",
+            "value": "http://example.com",
+        }
+    ]
+
+    response = identity.to_ap()
+
+    assert response["attachment"]
+    assert len(response["attachment"]) == 1
+
+    attachment = response["attachment"][0]
+
+    assert attachment["type"] == "PropertyValue"
+    assert attachment["name"] == "Website"
+    assert attachment["value"] == (
+        '<a href="http://example.com" rel="nofollow">'
+        '<span class="invisible">http://</span>example.com</a>'
+    )

--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -534,7 +534,7 @@ class Identity(StatorModel):
         if self.metadata:
             response["attachment"] = [
                 {
-                    "type": "http://schema.org#PropertyValue",
+                    "type": "PropertyValue",
                     "name": FediverseHtmlParser(item["name"]).plain_text,
                     "value": FediverseHtmlParser(item["value"]).html,
                 }


### PR DESCRIPTION
- Adds missing fan out process when we update the account using the API (mastodon clients case)
- Use type expected by mastodon