### PR TITLE
Fix canonicalize

### DIFF
--- a/core/ld.py
+++ b/core/ld.py
@@ -592,24 +592,32 @@ def canonicalise(json_data: dict, include_security: bool = False) -> dict:
     """
     if not isinstance(json_data, dict):
         raise ValueError("Pass decoded JSON data into LDDocument")
-    context = [
-        "https://www.w3.org/ns/activitystreams",
-        {
-            "blurhash": "toot:blurhash",
-            "Emoji": "toot:Emoji",
-            "focalPoint": {"@container": "@list", "@id": "toot:focalPoint"},
-            "Hashtag": "as:Hashtag",
-            "manuallyApprovesFollowers": "as:manuallyApprovesFollowers",
-            "sensitive": "as:sensitive",
-            "toot": "http://joinmastodon.org/ns#",
-            "votersCount": "toot:votersCount",
-            "featured": {"@id": "toot:featured", "@type": "@id"},
-        },
-    ]
+
+    context = json_data.get("@context", [])
+
+    if not isinstance(context, list):
+        context = [context]
+
+    if not context:
+        context.append("https://www.w3.org/ns/activitystreams")
+        context.append(
+            {
+                "blurhash": "toot:blurhash",
+                "Emoji": "toot:Emoji",
+                "focalPoint": {"@container": "@list", "@id": "toot:focalPoint"},
+                "Hashtag": "as:Hashtag",
+                "manuallyApprovesFollowers": "as:manuallyApprovesFollowers",
+                "sensitive": "as:sensitive",
+                "toot": "http://joinmastodon.org/ns#",
+                "votersCount": "toot:votersCount",
+                "featured": {"@id": "toot:featured", "@type": "@id"},
+            }
+        )
+
     if include_security:
         context.append("https://w3id.org/security/v1")
-    if "@context" not in json_data:
-        json_data["@context"] = context
+
+    json_data["@context"] = context
 
     return jsonld.compact(jsonld.expand(json_data), context)
 

--- a/core/ld.py
+++ b/core/ld.py
@@ -547,6 +547,18 @@ schemas = {
             }
         },
     },
+    "schema.org": {
+        "contentType": "application/ld+json",
+        "documentUrl": "https://schema.org/docs/jsonldcontext.json",
+        "contextUrl": None,
+        "document": {
+            "@context": {
+                "schema": "http://schema.org/",
+                "PropertyValue": {"@id": "schema:PropertyValue"},
+                "value": {"@id": "schema:value"},
+            },
+        },
+    },
 }
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.Z"

--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -854,16 +854,14 @@ class Identity(StatorModel):
         self.metadata = []
         for attachment in get_list(document, "attachment"):
             if (
-                attachment["type"] == "http://schema.org#PropertyValue"
+                attachment["type"] == "PropertyValue"
                 and "name" in attachment
-                and "http://schema.org#value" in attachment
+                and "value" in attachment
             ):
                 self.metadata.append(
                     {
-                        "name": attachment.get("name"),
-                        "value": FediverseHtmlParser(
-                            attachment.get("http://schema.org#value")
-                        ).html,
+                        "name": attachment["name"],
+                        "value": FediverseHtmlParser(attachment["value"]).html,
                     }
                 )
         # Now go do webfinger with that info to see if we can get a canonical domain


### PR DESCRIPTION
- Adds schema.org context to support gotosocial that mentions it directly (its context is huge, I only took the property value part that is the one used by attachment)
- Make canonicalize to use the json-ld context if provided instead of overriding it with a default one, this fixes most of the parsing errors that are happening during the validation process of the actors.