### PR TITLE
Be quieter about remote hosts with invalid SSL certs

### DIFF
--- a/activities/models/post.py
+++ b/activities/models/post.py
@@ -854,6 +854,7 @@ class Post(StatorModel):
                 if author.domain.blocked:
                     raise cls.DoesNotExist("Post is from a blocked domain")
                 try:
+                    print(f"attempting to create post with ID {data['id']}")
                     post = cls.objects.create(
                         object_uri=data["id"],
                         author=author,

--- a/activities/models/post_interaction.py
+++ b/activities/models/post_interaction.py
@@ -411,7 +411,11 @@ class PostInteraction(StatorModel):
                 # Resolve the post
                 object = data["object"]
                 target = get_str_or_id(object, "inReplyTo") or get_str_or_id(object)
-                post = Post.by_object_uri(target, fetch=True)
+                try:
+                    post = Post.by_object_uri(target, fetch=True)
+                except Post.DoesNotExist:
+                    # can't interact with a post we don't have
+                    return
                 value = None
                 # Get the right type
                 if data["type"].lower() == "like":

--- a/core/signatures.py
+++ b/core/signatures.py
@@ -4,6 +4,7 @@ from typing import Literal, TypedDict, cast
 from urllib.parse import urlparse
 
 import httpx
+from ssl import SSLError, SSLCertVerificationError
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
@@ -16,7 +17,6 @@ from idna.core import InvalidCodepoint
 from pyld import jsonld
 
 from core.ld import format_ld_date
-
 
 class VerificationError(BaseException):
     """
@@ -249,6 +249,10 @@ class HttpSignature:
                     content=body_bytes,
                     follow_redirects=method == "get",
                 )
+            except SSLError as e:
+                # Not our problem if the other end doesn't have proper SSL
+                print(f"{uri} {e}")
+                raise SSLCertVerificationError(e)
             except InvalidCodepoint as ex:
                 # Convert to a more generic error we handle
                 raise httpx.HTTPError(f"InvalidCodepoint: {str(ex)}") from None

--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -697,7 +697,7 @@ class Identity(StatorModel):
                 if (
                     response
                     and response.status_code < 500
-                    and response.status_code not in [401, 403, 404, 406, 410]
+                    and response.status_code not in [400, 401, 403, 404, 406, 410]
                 ):
                     raise ValueError(
                         f"Client error fetching webfinger: {response.status_code}",


### PR DESCRIPTION
I was getting a lot of extremely verbose log messages and sentry errors about SSLErrors from remote hosts. Since I can't do anything about a bad certificate on someone else's server, and the SSLError anyway prevented any processing with those hosts, this patch replaces the error with a one-liner log message:

` 2023-06-24T19:32:44.009595000Z https://some.skrolli.fi/users/skrollilehti [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1002)`