### PR TITLE
Add support to import Blocklist

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1346,6 +1346,10 @@ table.metadata td .emoji {
     cursor: pointer;
 }
 
+.announcement.error {
+    background-color: var(--color-bg-error);
+}
+
 /* Identity banner */
 
 .identity-banner {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1346,7 +1346,7 @@ table.metadata td .emoji {
     cursor: pointer;
 }
 
-.announcement.error {
+.message.error {
     background-color: var(--color-bg-error);
 }
 

--- a/takahe/urls.py
+++ b/takahe/urls.py
@@ -129,6 +129,11 @@ urlpatterns = [
         name="admin_federation",
     ),
     path(
+        "admin/federation/blocklist/",
+        admin.FederationBlocklist.as_view(),
+        name="admin_federation_blocklist",
+    ),
+    path(
         "admin/federation/<domain>/",
         admin.FederationEdit.as_view(),
         name="admin_federation_edit",

--- a/templates/admin/federation.html
+++ b/templates/admin/federation.html
@@ -8,6 +8,9 @@
         <input type="search" name="query" value="{{ query }}" placeholder="Search by domain">
         <button><i class="fa-solid fa-search"></i></button>
     </form>
+    <div class="view-options">
+        <a href="{% url "admin_federation_blocklist" %}?page={{ page_obj.number }}" class="button">Import Blocklist</a>
+    </div>
     <table class="items">
         {% for domain in page_obj %}
             <tr>

--- a/templates/admin/federation_blocklist.html
+++ b/templates/admin/federation_blocklist.html
@@ -1,0 +1,25 @@
+{% extends "admin/base_main.html" %}
+
+{% block subtitle %}Federation Blocklist{% endblock %}
+
+{% block settings_content %}
+    <form action="." method="POST" enctype="multipart/form-data">
+        {% csrf_token %}
+        <h1>Import Blocklist</h1>
+
+        {% if bad_format %}
+            <div class="announcement error">Error: The file you uploaded was not a valid blocklist CSV.</div>
+        {% endif %}
+        {% if success %}
+            <div class="announcement">Your blocklist CSV was processed processed with success!</div>
+        {% endif %}
+
+        <fieldset>
+            {% include "forms/_field.html" with field=form.blocklist %}
+        </fieldset>
+        <div class="buttons">
+            <a href="{% url "admin_federation" %}?page={{ page }}" class="button secondary left">Back</a>
+            <button>Save</button>
+        </div>
+    </form>
+{% endblock %}

--- a/templates/admin/federation_blocklist.html
+++ b/templates/admin/federation_blocklist.html
@@ -7,13 +7,6 @@
         {% csrf_token %}
         <h1>Import Blocklist</h1>
 
-        {% if bad_format %}
-            <div class="announcement error">Error: The file you uploaded was not a valid blocklist CSV.</div>
-        {% endif %}
-        {% if success %}
-            <div class="announcement">Your blocklist CSV was processed processed with success!</div>
-        {% endif %}
-
         <fieldset>
             {% include "forms/_field.html" with field=form.blocklist %}
         </fieldset>

--- a/tests/users/services/test_domain.py
+++ b/tests/users/services/test_domain.py
@@ -1,0 +1,11 @@
+import pytest
+
+from users.models import Domain
+from users.services import DomainService
+
+
+@pytest.mark.django_db
+def test_block():
+    DomainService.block(["block1.example.com", "block2.example.com"])
+
+    assert Domain.objects.filter(blocked=True).count() == 2

--- a/users/services/__init__.py
+++ b/users/services/__init__.py
@@ -1,3 +1,4 @@
 from .announcement import AnnouncementService  # noqa
+from .domain import DomainService  # noqa
 from .identity import IdentityService  # noqa
 from .user import UserService  # noqa

--- a/users/services/domain.py
+++ b/users/services/domain.py
@@ -1,0 +1,22 @@
+from users.models import Domain
+
+
+class DomainService:
+    """
+    High-level domain handling methods
+    """
+
+    @classmethod
+    def block(cls, domains: list[str]) -> None:
+        domains_to_block = Domain.objects.filter(domain__in=domains)
+        domains_to_block.update(blocked=True)
+
+        already_blocked = domains_to_block.values_list("domain", flat=True)
+        domains_to_create = []
+        for domain in domains:
+            if domain not in already_blocked:
+                domains_to_create.append(
+                    Domain(domain=domain, blocked=True, local=False)
+                )
+
+        Domain.objects.bulk_create(domains_to_create)

--- a/users/views/admin/__init__.py
+++ b/users/views/admin/__init__.py
@@ -23,7 +23,11 @@ from users.views.admin.emoji import (  # noqa
     EmojiEnable,
     EmojiRoot,
 )
-from users.views.admin.federation import FederationEdit, FederationRoot  # noqa
+from users.views.admin.federation import (  # noqa
+    FederationBlocklist,
+    FederationEdit,
+    FederationRoot,
+)
 from users.views.admin.hashtags import HashtagEdit, HashtagEnable, Hashtags  # noqa
 from users.views.admin.identities import IdentitiesRoot, IdentityEdit  # noqa
 from users.views.admin.invites import InviteCreate, InvitesRoot, InviteView  # noqa

--- a/users/views/admin/federation.py
+++ b/users/views/admin/federation.py
@@ -1,4 +1,7 @@
+import csv
+
 from django import forms
+from django.core.validators import FileExtensionValidator, ValidationError
 from django.db import models
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
@@ -6,11 +9,12 @@ from django.views.generic import FormView, ListView
 
 from users.decorators import admin_required
 from users.models import Domain
+from users.services import DomainService
+from users.views.admin.domains import DomainValidator
 
 
 @method_decorator(admin_required, name="dispatch")
 class FederationRoot(ListView):
-
     template_name = "admin/federation.html"
     paginate_by = 50
 
@@ -35,7 +39,6 @@ class FederationRoot(ListView):
 
 @method_decorator(admin_required, name="dispatch")
 class FederationEdit(FormView):
-
     template_name = "admin/federation_edit.html"
     extra_context = {"section": "federation"}
 
@@ -78,3 +81,58 @@ class FederationEdit(FormView):
             "blocked": self.domain.blocked,
             "notes": self.domain.notes,
         }
+
+
+@method_decorator(admin_required, name="dispatch")
+class FederationBlocklist(FormView):
+    template_name = "admin/federation_blocklist.html"
+    extra_context = {"section": "federation"}
+
+    class form_class(forms.Form):
+        blocklist = forms.FileField(
+            help_text=(
+                "Blocklist file with one domain per line. "
+                "Oliphant blocklist format is also supported."
+            ),
+            validators=[FileExtensionValidator(allowed_extensions=["txt", "csv"])],
+        )
+
+    def form_valid(self, form):
+        validator = DomainValidator()
+        domains = []
+
+        try:
+            lines = form.cleaned_data["blocklist"].read().decode("utf-8").splitlines()
+
+            if "#domain" in lines[0]:
+                reader = csv.DictReader(lines)
+            else:
+                reader = csv.DictReader(lines, fieldnames=["#domain"])
+
+            for row in reader:
+                domain = row["#domain"].strip()
+
+                try:
+                    validator(domain)
+                except ValidationError:
+                    # skip adding invalid domain
+                    # to the blocklist
+                    continue
+
+                domains.append(domain)
+        except (TypeError, ValueError):
+            return redirect(".?bad_format=true")
+
+        if not domains:
+            return redirect(".?bad_format=true")
+
+        DomainService.block(domains)
+
+        return redirect(".?success=true")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page"] = self.request.GET.get("page")
+        context["bad_format"] = self.request.GET.get("bad_format")
+        context["success"] = self.request.GET.get("success")
+        return context


### PR DESCRIPTION
First iteration of blocklist support

- Adds support to simple domain list file (one domain per line)
- Adds support to Oliphant blocklist format (https://writer.oliphant.social/oliphant/the-oliphant-social-blocklist)

In this version it blocks all domains in the list since we don't have yet support to globally silencing domains.

relates to #613