### PR TITLE
Allow updated to updated transition on Domain model

### DIFF
--- a/users/models/domain.py
+++ b/users/models/domain.py
@@ -23,6 +23,7 @@ class DomainStates(StateGraph):
 
     outdated.transitions_to(updated)
     updated.transitions_to(outdated)
+    updated.transitions_to(updated)
 
     outdated.transitions_to(connection_issue)
     outdated.transitions_to(purged)
@@ -45,6 +46,8 @@ class DomainStates(StateGraph):
 
     @classmethod
     def handle_updated(cls, instance: "Domain"):
+        if instance.blocked:
+            return cls.updated
         return cls.outdated
 
 

--- a/users/models/domain.py
+++ b/users/models/domain.py
@@ -45,8 +45,6 @@ class DomainStates(StateGraph):
 
     @classmethod
     def handle_updated(cls, instance: "Domain"):
-        if instance.blocked:
-            return cls.updated
         return cls.outdated
 
 


### PR DESCRIPTION
This fixes the error of a domain trying to transition from updated to updated by allowing the transition on DomainStates.

Closes: #620 