### PR TITLE
Support to export blocks/mutes as CSV files

### DIFF
--- a/takahe/urls.py
+++ b/takahe/urls.py
@@ -66,6 +66,16 @@ urlpatterns = [
         name="settings_export_followers_csv",
     ),
     path(
+        "@<handle>/settings/import_export/blocks.csv",
+        settings.CsvBlocks.as_view(),
+        name="settings_export_blocks_csv",
+    ),
+    path(
+        "@<handle>/settings/import_export/mutes.csv",
+        settings.CsvMutes.as_view(),
+        name="settings_export_mutes_csv",
+    ),
+    path(
         "@<handle>/settings/migrate_in/",
         settings.MigrateInPage.as_view(),
         name="settings_migrate_in",

--- a/templates/settings/import_export.html
+++ b/templates/settings/import_export.html
@@ -50,7 +50,7 @@
                         <small>{{ numbers.blocks }} {{ numbers.blocks|pluralize:"people,people" }}</small>
                     </td>
                     <td>
-
+                        <a href="{% url "settings_export_blocks_csv" handle=identity.handle %}">Download CSV</a>
                     </td>
                 </tr>
                 <tr>
@@ -59,7 +59,7 @@
                         <small>{{ numbers.mutes }} {{ numbers.mutes|pluralize:"people,people" }}</small>
                     </td>
                     <td>
-
+                        <a href="{% url "settings_export_mutes_csv" handle=identity.handle %}">Download CSV</a>
                     </td>
                 </tr>
             </table>

--- a/users/views/settings/__init__.py
+++ b/users/views/settings/__init__.py
@@ -6,8 +6,10 @@ from django.views.generic import View
 from users.views.settings.delete import DeleteIdentity  # noqa
 from users.views.settings.follows import FollowsPage  # noqa
 from users.views.settings.import_export import (  # noqa
+    CsvBlocks,
     CsvFollowers,
     CsvFollowing,
+    CsvMutes,
     ImportExportPage,
 )
 from users.views.settings.interface import InterfacePage  # noqa

--- a/users/views/settings/import_export.py
+++ b/users/views/settings/import_export.py
@@ -7,7 +7,7 @@ from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.views.generic import FormView, View
 
-from users.models import Follow, InboxMessage
+from users.models import Block, Follow, InboxMessage
 from users.views.base import IdentityViewMixin
 
 
@@ -147,3 +147,35 @@ class CsvFollowers(CsvView):
 
     def get_handle(self, follow: Follow):
         return follow.source.handle
+
+
+class CsvBlocks(CsvView):
+    columns = {
+        "Account address": "get_handle",
+    }
+
+    filename = "blocked_accounts.csv"
+
+    def get_queryset(self, request):
+        return self.identity.outbound_blocks.active().filter(mute=False)
+
+    def get_handle(self, block: Block):
+        return block.target.handle
+
+
+class CsvMutes(CsvView):
+    columns = {
+        "Account address": "get_handle",
+        "Hide notifications": "get_notification",
+    }
+
+    filename = "muted_accounts.csv"
+
+    def get_queryset(self, request):
+        return self.identity.outbound_blocks.active().filter(mute=True)
+
+    def get_handle(self, mute: Block):
+        return mute.target.handle
+
+    def get_notification(self, mute: Block):
+        return mute.include_notifications


### PR DESCRIPTION
This allows downloading the block list and mute list from the export page (`https://takahe.social/<username>/settings/import_export/`).

<img width="1151" alt="Screenshot 2023-08-02 at 1 53 24" src="https://github.com/jointakahe/takahe/assets/1425259/4a44e87a-b568-42e3-8bd0-54ecc2077e27">

I followed Mastodon's CSV format: https://mastodon.social/settings/export