### PR TITLE
Fix small syntax errors

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -122,7 +122,7 @@ be provided to the containers from the first boot.
 * If you want to support push notifications, set ``TAKAHE_VAPID_PUBLIC_KEY``
   and ``TAKAHE_VAPID_PRIVATE_KEY`` to a valid VAPID keypair (note that if you
   ever change these, push notifications will stop working). You can generate
-  a keypair at `https://web-push-codelab.glitch.me/`_.
+  a keypair at `<https://web-push-codelab.glitch.me/>`_.
 
 There are some other, optional variables you can tweak once the
 system is up and working - see :doc:`tuning` for more.

--- a/docs/tuning.rst
+++ b/docs/tuning.rst
@@ -30,7 +30,7 @@ using more resources if you give them to it), you can:
   has to send a copy of each of their posts to every follower, separately.
 
 * Takahe is run with Gunicorn which spawns several
-  [workers](https://docs.gunicorn.org/en/stable/settings.html#workers) to
+  `workers <https://docs.gunicorn.org/en/stable/settings.html#workers>`_ to
   handle requests. Depending on what environment you are running Takahe on,
   you might want to customize this via the ``GUNICORN_CMD_ARGS`` environment
   variable. For example - ``GUNICORN_CMD_ARGS="--workers 2"`` to set the


### PR DESCRIPTION
Just two small syntax errors found in the documentation.

## Before
<img width="897" alt="Screenshot 2023-08-06 at 20 45 32" src="https://github.com/jointakahe/takahe/assets/1425259/b1966037-2c6f-47bc-976c-61ba0a97207e">

<img width="885" alt="Screenshot 2023-08-06 at 20 48 02" src="https://github.com/jointakahe/takahe/assets/1425259/6c716607-8aef-417a-be16-24d40eeac455">

## After
<img width="971" alt="Screenshot 2023-08-06 at 20 45 13" src="https://github.com/jointakahe/takahe/assets/1425259/9edb4aa8-a61f-4ca6-ad19-f7d0d41c845a">

<img width="898" alt="Screenshot 2023-08-06 at 20 48 08" src="https://github.com/jointakahe/takahe/assets/1425259/8c82b6d6-9d98-4993-8571-5da53c2324b2">
