### PR TITLE
Add stub API endpoint for user suggestion (api/v2/suggestions)

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -18,6 +18,7 @@ from api.views import (
     push,
     search,
     statuses,
+    suggestions,
     tags,
     timelines,
     trends,
@@ -128,4 +129,6 @@ urlpatterns = [
     path("v1/trends/tags", trends.trends_tags),
     path("v1/trends/statuses", trends.trends_statuses),
     path("v1/trends/links", trends.trends_links),
+    # Suggestions
+    path("v2/suggestions", suggestions.suggested_users),
 ]

--- a/api/views/suggestions.py
+++ b/api/views/suggestions.py
@@ -1,0 +1,16 @@
+from django.http import HttpRequest
+from hatchway import api_view
+
+from api import schemas
+from api.decorators import scope_required
+
+
+@scope_required("read")
+@api_view.get
+def suggested_users(
+    request: HttpRequest,
+    limit: int = 10,
+    offset: int | None = None,
+) -> list[schemas.Account]:
+    # We don't implement this yet
+    return []


### PR DESCRIPTION
I'm testing Takahē with Elk now and fount "For you" tab always returns an error.

For you | Explore | Elk - https://elk.zone/takahe.social/explore/users
<img width="918" alt="Screenshot 2023-08-16 at 13 28 16" src="https://github.com/jointakahe/takahe/assets/1425259/9e6394a4-6902-4a59-9247-044bac388b6c">

I'm not sure if Takahē will have this functionality or not yet, but I think returning an empty response would be nice to have to avoid errors for now same as the existing trends endpoint.
