### PR TITLE
Fix Accept object id for follow activity for Misskey and Firefish

### DIFF
--- a/users/models/follow.py
+++ b/users/models/follow.py
@@ -230,7 +230,7 @@ class Follow(StatorModel):
         """
         return {
             "type": "Accept",
-            "id": self.uri + "#accept",
+            "id": self.target.actor_uri + "#accept/follows/",
             "actor": self.target.actor_uri,
             "object": self.to_ap(),
         }

--- a/users/models/follow.py
+++ b/users/models/follow.py
@@ -230,7 +230,7 @@ class Follow(StatorModel):
         """
         return {
             "type": "Accept",
-            "id": self.target.actor_uri + "#accept/follows/",
+            "id": f"{self.target.actor_uri}#accept/{self.id}",
             "actor": self.target.actor_uri,
             "object": self.to_ap(),
         }


### PR DESCRIPTION
fix #323

Yes, adjusting the `id` of `Accept` object was enough to fix this issue.

Do you know the meaning of the hash part? I couldn't find an explanation in ActivityPub spec so I just tried mimicking Mastodon's `Accept` object and it seems to work (I haven't tested yet but maybe just `#accept` could be ok).

Example object is now like this:

```diff
 {
   'type': 'Accept'
-  'id': 'https://misskey.io/follows/9iiw862tea#accept',
+  'id': 'https://takahe.shuuji3.xyz/@shuuji3@takahe.shuuji3.xyz/#accept/follows/',
   'actor': 'https://takahe.shuuji3.xyz/@shuuji3@takahe.shuuji3.xyz/',
   'object': {
     'type': 'Follow',
     'id': 'https://misskey.io/follows/9iiw862tea',
     'actor': 'https://misskey.io/users/97swdg10sa',
     'object': 'https://takahe.shuuji3.xyz/@shuuji3@takahe.shuuji3.xyz/'
   }
 }
```

I confirmed that Misskey now can follow the Takahē account:
<img width="848" alt="Screenshot 2023-08-18 at 2 32 34" src="https://github.com/jointakahe/takahe/assets/1425259/d9df8490-cc63-4832-96c3-075243a3c1ec">

Also, Firefish too:
<img width="799" alt="Screenshot 2023-08-18 at 1 14 29" src="https://github.com/jointakahe/takahe/assets/1425259/168c69a8-d415-4e72-bbc9-57948ccf8b5d">

They can see replies and new posts from Takahē after the successful following.