### PR TITLE
signatures need to use UTF-8 in order to represent all URLs

### DIFF
--- a/core/signatures.py
+++ b/core/signatures.py
@@ -140,7 +140,7 @@ class HttpSignature:
         try:
             public_key_instance.verify(
                 signature,
-                cleartext.encode("ascii"),
+                cleartext.encode("utf8"),
                 padding.PKCS1v15(),
                 hashes.SHA256(),
             )
@@ -229,7 +229,7 @@ class HttpSignature:
             ),
         )
         signature = private_key_instance.sign(
-            signed_string.encode("ascii"),
+            signed_string.encode("utf8"),
             padding.PKCS1v15(),
             hashes.SHA256(),
         )


### PR DESCRIPTION
Noticed this as an error pulling some signed requests as URLs with international character sets couldn't be encoded. Having reviewed Mastodon implementation, I believe it is correct to encode URLs using UTF-8. This changes nothing for majority of content since ASCII charset encodes the same way.