### PR TITLE
do not print "Scheduling 0 handled" 

### DIFF
--- a/stator/runner.py
+++ b/stator/runner.py
@@ -163,9 +163,9 @@ class StatorRunner:
         """
         with sentry.start_transaction(op="task", name="stator.run_scheduling"):
             for model in self.models:
-                print(
-                    f"{model._meta.label_lower}: Scheduling ({self.handled.get(model._meta.label_lower, 0)} handled)"
-                )
+                num = self.handled.get(model._meta.label_lower, 0)
+                if num or settings.DEBUG:
+                    print(f"{model._meta.label_lower}: Scheduling ({num} handled)")
                 self.submit_stats(model)
                 model.transition_clean_locks()
 


### PR DESCRIPTION
unless settings.DEBUG is on, so that it's less noisy for less busy nodes.

I personally prefer not to print it at all regardless of DEBUG, but assume it was there for a reason?