### PR TITLE
Do not canonicalise non json content in the search endpoint

### DIFF
--- a/activities/services/search.py
+++ b/activities/services/search.py
@@ -81,6 +81,9 @@ class SearchService:
             return None
         if response.status_code >= 400:
             return None
+        content_type = response.headers.get("Content-Type", "").lower()
+        if content_type not in ["application/json", "application/ld+json"]:
+            return None
         document = canonicalise(response.json(), include_security=True)
         type = document.get("type", "unknown").lower()
 


### PR DESCRIPTION
While testing https://phanpy.social/ web client I noticed it calls the search API with the links found in the posts to do some clever discovery magic.

But by doing so it makes the service to search for things that returns with 200 but are not json content, so we get some serialization crashes.

This checks for the response `Content-Type` before trying to do json parsing and canonicalization.