### PR TITLE
Improve search api json parsing

### DIFF
--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -1,0 +1,115 @@
+import pytest
+from pytest_httpx import HTTPXMock
+
+test_account_json = r"""
+{
+   "@context":[
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/v1",
+      {
+         "manuallyApprovesFollowers":"as:manuallyApprovesFollowers",
+         "toot":"http://joinmastodon.org/ns#",
+         "featured":{
+            "@id":"toot:featured",
+            "@type":"@id"
+         },
+         "featuredTags":{
+            "@id":"toot:featuredTags",
+            "@type":"@id"
+         },
+         "movedTo":{
+            "@id":"as:movedTo",
+            "@type":"@id"
+         },
+         "schema":"http://schema.org#",
+         "PropertyValue":"schema:PropertyValue",
+         "value":"schema:value",
+         "discoverable":"toot:discoverable",
+         "Device":"toot:Device",
+         "deviceId":"toot:deviceId",
+         "messageType":"toot:messageType",
+         "cipherText":"toot:cipherText",
+         "suspended":"toot:suspended",
+         "memorial":"toot:memorial",
+         "indexable":"toot:indexable"
+      }
+   ],
+   "id":"https://search.example.com/users/searchtest",
+   "type":"Person",
+   "following":"https://search.example.com/users/searchtest/following",
+   "followers":"https://search.example.com/users/searchtest/followers",
+   "inbox":"https://search.example.com/users/searchtest/inbox",
+   "outbox":"https://search.example.com/users/searchtest/outbox",
+   "featured":"https://search.example.com/users/searchtest/collections/featured",
+   "featuredTags":"https://search.example.com/users/searchtest/collections/tags",
+   "preferredUsername":"searchtest",
+   "name":"searchtest",
+   "summary":"<p>The official searchtest account for the instance.</p>",
+   "url":"https://search.example.com/@searchtest",
+   "manuallyApprovesFollowers":false,
+   "discoverable":true,
+   "indexable":false,
+   "published":"2018-05-09T00:00:00Z",
+   "memorial":false,
+   "devices":"https://search.example.com/users/searchtest/collections/devices",
+   "endpoints":{
+      "sharedInbox":"https://search.example.com/inbox"
+   }
+}
+"""
+
+
+@pytest.mark.django_db
+def test_search_not_found(httpx_mock: HTTPXMock, api_client):
+    httpx_mock.add_response(status_code=404)
+    response = api_client.get(
+        "/api/v2/search",
+        content_type="application/json",
+        data={
+            "q": "https://notfound.example.com",
+        },
+    ).json()
+
+    assert response["accounts"] == []
+    assert response["statuses"] == []
+    assert response["hashtags"] == []
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "encoding",
+    [
+        "utf-8",
+        "iso-8859-1",
+    ],
+)
+@pytest.mark.parametrize(
+    "content_type",
+    [
+        "application/json",
+        "application/ld+json",
+        "application/activity+json",
+    ],
+)
+def test_search(
+    content_type: str,
+    encoding: str,
+    httpx_mock: HTTPXMock,
+    api_client,
+):
+    httpx_mock.add_response(
+        headers={"Content-Type": f"{content_type}; charset={encoding}"},
+        content=test_account_json.encode(encoding),
+    )
+
+    response = api_client.get(
+        "/api/v2/search",
+        content_type="application/json",
+        data={
+            "q": "https://search.example.com/users/searchtest",
+        },
+    ).json()
+
+    assert len(response["accounts"]) == 1
+    assert response["accounts"][0]["acct"] == "searchtest@search.example.com"
+    assert response["accounts"][0]["username"] == "searchtest"


### PR DESCRIPTION
The `Content-Type` http header not only can have the actual type of the payload but also can return the charset and other optional parameters like defined in [HTTP/1.1 RFC](https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.5).

So Content-Type like the following were getting skipped by our checks:

```text
Content-Type: text/html; charset=utf-8
```

To make it more robust I took in consideration the charset to parse the json content from the request, and also added some tests to cover this endpoint.