### PR TITLE
Extract json parser to core and use in fetch_actor

### DIFF
--- a/core/json.py
+++ b/core/json.py
@@ -13,7 +13,7 @@ def json_from_response(response: Response) -> dict | None:
     content_type, *parameters = (
         response.headers.get("Content-Type", "invalid").lower().split(";")
     )
-    print(content_type, parameters)
+
     if content_type not in JSON_CONTENT_TYPES:
         return None
 

--- a/core/json.py
+++ b/core/json.py
@@ -1,0 +1,32 @@
+import json
+
+from httpx import Response
+
+JSON_CONTENT_TYPES = [
+    "application/json",
+    "application/ld+json",
+    "application/activity+json",
+]
+
+
+def json_from_response(response: Response) -> dict | None:
+    content_type, *parameters = (
+        response.headers.get("Content-Type", "invalid").lower().split(";")
+    )
+    print(content_type, parameters)
+    if content_type not in JSON_CONTENT_TYPES:
+        return None
+
+    charset = None
+
+    for parameter in parameters:
+        key, value = parameter.split("=")
+        if key.strip() == "charset":
+            charset = value.strip()
+
+    if charset:
+        return json.loads(response.content.decode(charset))
+    else:
+        # if no charset informed, default to
+        # httpx json for encoding inference
+        return response.json()

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -44,7 +44,7 @@ test_account_json = r"""
    "featuredTags":"https://search.example.com/users/searchtest/collections/tags",
    "preferredUsername":"searchtest",
    "name":"searchtest",
-   "summary":"<p>The official searchtest account for the instance.</p>",
+   "summary":"<p>Just a test (àáâãäåæ)</p>",
    "url":"https://search.example.com/@searchtest",
    "manuallyApprovesFollowers":false,
    "discoverable":true,
@@ -113,3 +113,4 @@ def test_search(
     assert len(response["accounts"]) == 1
     assert response["accounts"][0]["acct"] == "searchtest@search.example.com"
     assert response["accounts"][0]["username"] == "searchtest"
+    assert response["accounts"][0]["note"] == "<p>Just a test (àáâãäåæ)</p>"

--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -14,6 +14,7 @@ from lxml import etree
 
 from core.exceptions import ActorMismatchError
 from core.html import ContentRenderer, FediverseHtmlParser
+from core.json import json_from_response
 from core.ld import (
     canonicalise,
     format_ld_date,
@@ -878,8 +879,11 @@ class Identity(StatorModel):
                     "Client error fetching actor: %d %s", status_code, self.actor_uri
                 )
             return False
+        json_data = json_from_response(response)
+        if not json_data:
+            return False
         try:
-            document = canonicalise(response.json(), include_security=True)
+            document = canonicalise(json_data, include_security=True)
         except ValueError:
             # servers with empty or invalid responses are inevitable
             logger.info(


### PR DESCRIPTION
Following with the improvement to the search #662 there's a second fetch that is made by the fetch_actor during the search request to the api, so when adding characters that may break in the wrong encoding to the payload we can see the need to make the same fix to the fetch_actor method.

I then extracted the function to core module so it can be reused.

Obs.: We may need to reuse it in other places where we fetch json or json-like content, but I'll keep this PR sort by only covering the path impacted by the test.