### PR TITLE
do not retry unmute if mute never expires

### DIFF
--- a/users/models/block.py
+++ b/users/models/block.py
@@ -195,8 +195,7 @@ class Block(StatorModel):
             raise ValueError("You cannot mute from a remote Identity")
         block = cls.maybe_get(source=source, target=target, mute=True)
         if block is not None:
-            if not block.active:
-                block.state = BlockStates.new  # type:ignore
+            block.state = BlockStates.new  # type:ignore
             if duration:
                 block.expires = timezone.now() + datetime.timedelta(seconds=duration)
             block.include_notifications = include_notifications

--- a/users/models/block.py
+++ b/users/models/block.py
@@ -37,7 +37,7 @@ class BlockStates(StateGraph):
         """
         # Mutes don't send but might need expiry
         if instance.mute:
-            return cls.awaiting_expiry
+            return cls.awaiting_expiry if instance.expires else cls.sent
         # Remote blocks should not be here, local blocks just work
         if not instance.source.local or instance.target.local:
             return cls.sent


### PR DESCRIPTION
it seems currently the mute state stuck in `awaiting_expiry` and loop every hour even if it does not have to.

let me know if I should add migration like
```
update users_block set state = 'sent' where mute=true and expires is null;
```