### PR TITLE
do not make local identity outdated

### DIFF
--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -139,7 +139,7 @@ class IdentityStates(StateGraph):
 
     @classmethod
     def handle_updated(cls, instance: "Identity"):
-        if instance.state_age > Config.system.identity_max_age:
+        if not instance.local and instance.state_age > Config.system.identity_max_age:
             return cls.outdated
 
 


### PR DESCRIPTION
it seems currently local identity flip back to `outdated` every 15 days unnecessarily, this commit fixes that. 

a better solution might be having a dedicated `local_updated` state which never retry, but that requires much more change and I'll save it for another day.