### PR TITLE
Fix unnecessay webfinger when mentioning local identity

### DIFF
--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -400,6 +400,8 @@ class Identity(StatorModel):
             domain = domain.domain
         else:
             domain = domain.lower()
+            domain_instance = Domain.get_domain(domain)
+            local = domain_instance.local if domain_instance else local
 
         with transaction.atomic():
             try:


### PR DESCRIPTION
Currently when creating a local post mentioning a local identity, the server will query itself via webfinger which seems unnecessary. This patch fixes that.

