### PR TITLE
improve identity deletion

### DIFF
--- a/activities/models/post.py
+++ b/activities/models/post.py
@@ -583,7 +583,7 @@ class Post(StatorModel):
                 domain=domain,
                 fetch=True,
             )
-            if identity is not None:
+            if identity is not None and not identity.deleted:
                 mentions.add(identity)
         return mentions
 

--- a/users/models/follow.py
+++ b/users/models/follow.py
@@ -81,7 +81,9 @@ class FollowStates(StateGraph):
             except httpx.RequestError:
                 return
             return cls.pending_approval
-        # local/remote follow local, check manually_approve
+        # local/remote follow local, check deleted & manually_approve
+        if instance.target.deleted:
+            return cls.rejecting
         if instance.target.manually_approves_followers:
             from activities.models import TimelineEvent
 


### PR DESCRIPTION
 - disable all current login tokens
 - ignore new mention
 - ignore new follow
 - delete all data
 - fanout delete posts, interactions
 - fanout unfollow both directions
 - fanout nullified identity, then fanout delete identity
 - keep nullified identity for 7 days then delete forever