### PR TITLE
basic protection against invalid domain names

### DIFF
--- a/tests/users/models/test_domain.py
+++ b/tests/users/models/test_domain.py
@@ -3,6 +3,36 @@ import pytest
 from users.models import Domain
 
 
+def test_valid_domain():
+    """
+    Tests that a valid domain is valid
+    """
+
+    assert Domain.is_valid_domain("example.com")
+    assert Domain.is_valid_domain("xn----gtbspbbmkef.xn--p1ai")
+    assert Domain.is_valid_domain("underscore_subdomain.example.com")
+    assert Domain.is_valid_domain("something.versicherung")
+    assert Domain.is_valid_domain("11.com")
+    assert Domain.is_valid_domain("a.cn")
+    assert Domain.is_valid_domain("sub1.sub2.sample.co.uk")
+    assert Domain.is_valid_domain("somerandomexample.xn--fiqs8s")
+    assert not Domain.is_valid_domain("über.com")
+    assert not Domain.is_valid_domain("example.com:4444")
+    assert not Domain.is_valid_domain("example.-com")
+    assert not Domain.is_valid_domain("foo@bar.com")
+    assert not Domain.is_valid_domain("example.")
+    assert not Domain.is_valid_domain("example.com.")
+    assert not Domain.is_valid_domain("-example.com")
+    assert not Domain.is_valid_domain("_example.com")
+    assert not Domain.is_valid_domain("_example._com")
+    assert not Domain.is_valid_domain("example_.com")
+    assert not Domain.is_valid_domain("example")
+    assert not Domain.is_valid_domain("a......b.com")
+    assert not Domain.is_valid_domain("a.123")
+    assert not Domain.is_valid_domain("123.123")
+    assert not Domain.is_valid_domain("123.123.123.123")
+
+
 @pytest.mark.django_db
 def test_recursive_block():
     """

--- a/users/shortcuts.py
+++ b/users/shortcuts.py
@@ -18,6 +18,8 @@ def by_handle_or_404(request, handle, local=True, fetch=False) -> Identity:
         domain = domain_instance.domain
     else:
         username, domain = handle.split("@", 1)
+        if not Domain.is_valid_domain(domain):
+            raise Http404("Invalid domain")
         # Resolve the domain to the display domain
         domain_instance = Domain.get_domain(domain)
         if domain_instance is None:


### PR DESCRIPTION
current behavior is very insecure, this patch solves part of problem but not all 

e.g. https://mysite.com/@abc@whatever/posts/123/ will create garbage data in database, which is a bit insecure, but the data is at least marked as `connection_issue` after some stator cycle. however, if attacker uses https://mysite.com/@abc@whatever@mysite.com/posts/123/ , the domain `whatever@mysite.com` in db will look valid (state=updated and local=False), which might be used to construct further attacks. this patch solves the latter issue by validate domain before saving to db. this patch also prevent `localhost` from used

a future patch IMHO should be implemented to protect against more cases.