### PR TITLE
Fix federating with GoToSocial

### DIFF
--- a/core/signatures.py
+++ b/core/signatures.py
@@ -192,7 +192,7 @@ class HttpSignature:
         body: dict | None,
         private_key: str,
         key_id: str,
-        content_type: str = "application/json",
+        content_type: str = "application/activity+json",
         method: Literal["get", "post"] = "post",
         timeout: TimeoutTypes = settings.SETUP.REMOTE_TIMEOUT,
     ):


### PR DESCRIPTION
Federation with GTS has been broken bc it does not accept `application/json` and returns HTTP 406

```
Error #01: Content-Type application/json not acceptable, this endpoint accepts: [\"application/activity+json\" \"application/ld+json;profile=https://w3.org/ns/activitystreams\"]
```

https://github.com/superseriousbusiness/gotosocial/blob/v0.13.0/internal/federation/federatingactor.go#L44

Spot checked a few, so far the change seems not breaking federating with other software. 