### PR TITLE
Fix accept/reject remote follow request

### DIFF
--- a/users/models/follow.py
+++ b/users/models/follow.py
@@ -282,7 +282,7 @@ class Follow(StatorModel):
         """
         return {
             "type": "Accept",
-            "id": self.uri + "#accept",
+            "id": f"{self.target.actor_uri}follow/{self.id}/#accept",
             "actor": self.target.actor_uri,
             "object": self.to_ap(),
         }
@@ -293,7 +293,7 @@ class Follow(StatorModel):
         """
         return {
             "type": "Reject",
-            "id": self.uri + "#reject",
+            "id": f"{self.target.actor_uri}follow/{self.id}/#reject",
             "actor": self.target.actor_uri,
             "object": self.to_ap(),
         }


### PR DESCRIPTION
When accept or reject a remote follow request from Pleroma/Firefish/Misskey/etc, the `id` in the message should match the local actor, at least for the host name part.

The issue was brought up previously and correctly pinpointed in #323. However, the last commit in #323 seemed incorrect. This PR intend to fix that for good.