### PR TITLE
Workaround: 'as:Public' not recognized by many implementations

### DIFF
--- a/users/views/activitypub.py
+++ b/users/views/activitypub.py
@@ -139,7 +139,9 @@ class Inbox(View):
         if len(request.body) > settings.JSONLD_MAX_SIZE:
             return HttpResponseBadRequest("Payload size too large")
         # Load the LD
-        document = canonicalise(json.loads(request.body), include_security=True)
+        document = canonicalise(
+            json.loads(request.body), include_security=True, outbound=False
+        )
         document_type = document["type"]
         document_subtype = None
         if isinstance(document.get("object"), dict):


### PR DESCRIPTION
Many implementations, e.g. Pleroma and many relays, do not recognize `as:Public`, but only know `https://www.w3.org/ns/activitystreams#Public` in to/cc for public posts. This causes public posts from Takahe being rejected or ignored.

This patches outbound json to use full uri instead of as:Public. This is more of hack than a proper implementation. Suggestions and improvements are welcomed. 