### PR TITLE
fix when report ap message does not have content field

### DIFF
--- a/users/models/report.py
+++ b/users/models/report.py
@@ -172,7 +172,7 @@ class Report(StatorModel):
             subject_post=subject_post,
             source_domain=Domain.get_remote_domain(domain_id),
             type="remote",
-            complaint=data.get("content"),
+            complaint=str(data.get("content", "")),
         )
 
     def to_ap(self):


### PR DESCRIPTION
It seems report message from Pleroma may not have `content` field. 