### PR TITLE
Fix wrong summary class name construction

### DIFF
--- a/activities/models/post.py
+++ b/activities/models/post.py
@@ -460,7 +460,7 @@ class Post(StatorModel):
         """
         if not self.summary:
             return ""
-        return "summary-{self.id}"
+        return f"summary-{self.id}"
 
     @property
     def stats_with_defaults(self):


### PR DESCRIPTION
fix #715

The comment on the Issue (https://github.com/jointakahe/takahe/issues/715#issuecomment-2132775693) was the exact cause of the issue. The correct f-string can construct the proper class name for Hyperscript.


## Screenshots

### Before
![Screenshot from 2024-05-27 19-33-10](https://github.com/jointakahe/takahe/assets/1425259/20bb6927-135c-4860-a1e1-7fe0180f5a20)

### After
![Screenshot from 2024-05-27 19-32-32](https://github.com/jointakahe/takahe/assets/1425259/76b286fb-f4db-4095-8f18-fb327db07354)
